### PR TITLE
Remove tournament initialisation from Metadata

### DIFF
--- a/Plugins/Chasm Other/Globals/GlobalMetadata.rb
+++ b/Plugins/Chasm Other/Globals/GlobalMetadata.rb
@@ -100,8 +100,6 @@ class PokemonGlobalMetadata
     attr_accessor :shouldProcWhitebloomCall
     attr_accessor :shouldProcEstateCall
     attr_accessor :shouldProcJovanCall
-    # Tournament
-    attr_accessor :tournament
     # Dragon flames
     attr_writer :dragonFlamesCount
     # Circuit puzzles
@@ -195,8 +193,6 @@ class PokemonGlobalMetadata
 
         # Achievements
         @capture_counts_per_ball = {}
-
-        @tournament = RandomTournament.new
 
         # Regi dungeon puzzles
         @dragonFlamesCount = 0


### PR DESCRIPTION
Is a Tectonic-specific feature and should not be on the Engine. It largely wasn't, meaning this line caused crashes on a new game, which means the Engine can't be used for testing.

https://github.com/Pokemon-Tectonic-Team/Pokemon-Tectonic-Content/pull/17 should be merged before this is synced so that the Tournament still functions on Tectonic. There shouldn't be conflicts.