### PR TITLE
Fix how Staple moves are treated in PBS compile

### DIFF
--- a/Plugins/Chasm Game Data/Compiled Data/Species.rb
+++ b/Plugins/Chasm Game Data/Compiled Data/Species.rb
@@ -487,8 +487,11 @@ module GameData
             inherited_moves.each do |moveID|
                 nonInheritedTutorMoves.delete(moveID)
             end
-            GameData::Move.staple_moves do |moveID|
-                nonInheritedTutorMoves.delete(moveID)
+            # only remove staple moves as inherited if that's actually why we have the moves
+            unless @flags&.include?("NoStaples")
+                GameData::Move.staple_moves do |moveID|
+                    nonInheritedTutorMoves.delete(moveID)
+                end
             end
             return nonInheritedTutorMoves
         end
@@ -498,8 +501,10 @@ module GameData
             inherited_moves.each do |moveID|
                 nonInheritedLineMoves.delete(moveID)
             end
-            GameData::Move.staple_moves.each do |moveID|
-                nonInheritedLineMoves.delete(moveID)
+            unless @flags&.include?("NoStaples")
+                GameData::Move.staple_moves.each do |moveID|
+                    nonInheritedLineMoves.delete(moveID)
+                end
             end
             return nonInheritedLineMoves
         end


### PR DESCRIPTION
Staple moves are removed from the PBS files on compile since they shouldn't need to be explicitly included. However, this should not apply to Pokemon with the NoStaples flag, since they could have individual staple moves legitimately