### PR TITLE
Add second "available by level" parameter to encounters

### DIFF
--- a/Plugins/Chasm Game Data/Compiled Data/Encounters.rb
+++ b/Plugins/Chasm Game Data/Compiled Data/Encounters.rb
@@ -4,7 +4,8 @@ module GameData
       attr_accessor :map
       attr_accessor :version
       attr_reader :step_chances
-      attr_reader :available_levels
+      attr_reader :min_available_levels
+      attr_reader :normal_available_levels
       attr_reader :types
       attr_reader :defined_in_extension
   
@@ -64,7 +65,8 @@ module GameData
         @map          = hash[:map]
         @version      = hash[:version]      || 0
         @step_chances = hash[:step_chances]
-        @available_levels = hash[:available_levels]
+        @min_available_levels = hash[:min_available_levels]
+        @normal_available_levels = hash[:normal_available_levels]
         @types        = hash[:types]        || {}
         @defined_in_extension = hash[:defined_in_extension] || false
       end
@@ -81,7 +83,8 @@ module Compiler
       new_format        = nil
       encounter_hash    = nil
       step_chances      = nil
-      available_levels  = nil
+      min_available_levels  = nil
+      normal_available_levels  = nil
       need_step_chances = false   # Not needed for new format only
       probabilities     = nil     # Not needed for new format only
       current_type      = nil
@@ -163,14 +166,16 @@ module Compiler
               raise _INTL("Encounters for map '{1}' are defined twice.\r\n{2}", map_number, FileLineData.linereport)
             end
             step_chances = {}
-            available_levels = {}
+            min_available_levels = {}
+            normal_available_levels = {}
             # Construct encounter hash
             encounter_hash = {
               :id           => key,
               :map          => map_number,
               :version      => map_version,
               :step_chances => step_chances,
-              :available_levels => available_levels,
+              :min_available_levels => min_available_levels,
+              :normal_available_levels => normal_available_levels,
               :types        => {},
               :defined_in_extension => !baseFile
             }
@@ -207,14 +212,16 @@ module Compiler
               raise _INTL("Encounters for map '{1}' are defined twice.\r\n{2}", map_number, FileLineData.linereport)
             end
             step_chances = {}
-            available_levels = {}
+            min_available_levels = {}
+            normal_available_levels = {}
             # Construct encounter hash
             encounter_hash = {
               :id           => key,
               :map          => map_number,
               :version      => 0,
               :step_chances => step_chances,
-              :available_levels => available_levels,
+              :min_available_levels => min_available_levels,
+              :normal_available_levels => normal_available_levels,
               :types        => {},
               :defined_in_extension => !baseFile
             }
@@ -244,14 +251,15 @@ module Compiler
               need_step_chances = false
               if current_type == :Special
                 # Special encounters skip step chances and have available level as their only parameter
-                available_levels[current_type] = values[1].to_i if values[1] && !values[1].empty?
+                normal_available_levels[current_type] = values[1].to_i if values[1] && !values[1].empty?
               else
                 step_chances[current_type] = values[1].to_i if values[1] && !values[1].empty?
                 step_chances[current_type] ||= GameData::EncounterType.get(current_type).trigger_chance
               end
               probabilities = GameData::EncounterType.get(current_type).old_slots
               expected_lines = probabilities.length
-              available_levels[current_type] = values[2].to_i if values[2] && !values[2].empty?
+              min_available_levels[current_type] = values[2].to_i if values[2] && !values[2].empty?
+              normal_available_levels[current_type] = values[3].to_i if values[3] && !values[3].empty?
               encounter_hash[:types][current_type] = []
             else
               raise _INTL("Undefined encounter type \"{1}\" for map '{2}'.\r\n{3}",
@@ -305,15 +313,23 @@ module Compiler
         end
         encounter_data.types.each do |type, slots|
           next if !slots || slots.length == 0
+          min_level = encounter_data.min_available_levels[type]
+          normal_level = encounter_data.normal_available_levels[type]
+          has_min = min_level && min_level > 0
+          has_normal = normal_level && normal_level > 0
           if encounter_data.step_chances[type] && encounter_data.step_chances[type] > 0
-            if encounter_data.available_levels[type] && encounter_data.available_levels[type] > 0
-              f.write(sprintf("%s,%d,%d\r\n", type.to_s, encounter_data.step_chances[type], encounter_data.available_levels[type]))
-            else 
+            if has_min && has_normal
+              f.write(sprintf("%s,%d,%d,%d\r\n", type.to_s, encounter_data.step_chances[type], min_level, normal_level))
+            elsif has_min
+              f.write(sprintf("%s,%d,%d\r\n", type.to_s, encounter_data.step_chances[type], min_level))
+            else
               f.write(sprintf("%s,%d\r\n", type.to_s, encounter_data.step_chances[type]))
             end
           else
-            if encounter_data.available_levels[type] && encounter_data.available_levels[type] > 0
-              f.write(sprintf("%s,%d\r\n", type.to_s, encounter_data.available_levels[type]))
+            if has_min && has_normal
+              f.write(sprintf("%s,,%d,%d\r\n", type.to_s, min_level, normal_level))
+            elsif has_min
+              f.write(sprintf("%s,,%d\r\n", type.to_s, min_level))
             else
               f.write(sprintf("%s\r\n", type.to_s))
             end

--- a/Plugins/Chasm Game Data/Compiled Data/Species.rb
+++ b/Plugins/Chasm Game Data/Compiled Data/Species.rb
@@ -42,6 +42,7 @@ module GameData
         attr_reader :mega_message
         attr_reader :notes
         attr_accessor :earliest_available
+        attr_accessor :earliest_available_normal
         attr_reader :flags
         attr_reader :formalizer
         attr_reader :sticky_items
@@ -188,6 +189,7 @@ module GameData
             @mega_message          = hash[:mega_message]          || 0
             @notes                 = hash[:notes]                 || ""
             @earliest_available    = nil
+            @earliest_available_normal = nil
             @tribes                = hash[:tribes]                || []
             @defined_in_extension  = hash[:defined_in_extension]  || false
             @flags                 = hash[:flags]                 || []
@@ -562,9 +564,11 @@ module GameData
             return FORM_SPECIFIC_MOVES[@species]
         end
 
-        def available_by?(level)
-            return false unless earliest_available
-            return level >= earliest_available
+        # "normal" here refers to obtaining pokemon by normal means, not going out of your way to sequence break
+        def available_by?(level, normal = false)
+            query = normal ? earliest_available_normal : earliest_available
+            return false unless query
+            return level >= query
         end
 
         def get_prevolutions(exclude_invalid = true)
@@ -1069,28 +1073,35 @@ module Compiler
     # Determine the earliest you can aquire each species in the game
     #=============================================================================
     def compile_species_earliest_levels
-        # A hash of all species in the game that can be aquired directly
+        # Hashes of all species in the game that can be aquired directly
         # where the key is the species ID and the value is the earliest level they can be directly aquired
-        earliestWildEncounters = {}
+        earliestWildEncountersMin = {}
+        earliestWildEncountersNormal = {}
 
         # Checking every single map in the game for encounters
         GameData::Encounter.each_of_version do |enc_data|
             # For each slot in that encounters data listing
             enc_data.types.each do |key, slots|
                 next unless slots
-                earliestLevelForSlot = enc_data.available_levels[key] || 100
+                # Track min and normal levels separately
+                minLevelForSlot = enc_data.min_available_levels[key] || enc_data.normal_available_levels[key] || 100
+                normalLevelForSlot = enc_data.normal_available_levels[key] || enc_data.min_available_levels[key] || 100
                 slots.each do |slot|
                     species = GameData::Species.get(slot[1]).species # get base form
-                    if !earliestWildEncounters.has_key?(species) || earliestWildEncounters[species] > earliestLevelForSlot
-                        earliestWildEncounters[species] = earliestLevelForSlot
+                    if !earliestWildEncountersMin.has_key?(species) || earliestWildEncountersMin[species] > minLevelForSlot
+                        earliestWildEncountersMin[species] = minLevelForSlot
+                    end
+                    if !earliestWildEncountersNormal.has_key?(species) || earliestWildEncountersNormal[species] > normalLevelForSlot
+                        earliestWildEncountersNormal[species] = normalLevelForSlot
                     end
                 end
             end
         end
 
-        # A hash where the key is a species
+        # Hashes where the key is a species
         # and the value is a hash that describes different ways of aquiring it
-        earliestAquisition = earliestWildEncounters.clone
+        earliestAquisitionMin = earliestWildEncountersMin.clone
+        earliestAquisitionNormal = earliestWildEncountersNormal.clone
 
         iterationCount = 0
         loop do
@@ -1098,8 +1109,11 @@ module Compiler
             iterationCount += 1
             GameData::Species.each do |speciesData|
                 species = speciesData.id
-                next unless earliestAquisition.has_key?(species)
-                earliestLevelForBase = earliestAquisition[species]
+                hasMin = earliestAquisitionMin.has_key?(species)
+                hasNormal = earliestAquisitionNormal.has_key?(species)
+                next unless hasMin || hasNormal
+                earliestLevelForBaseMin = earliestAquisitionMin[species] if hasMin
+                earliestLevelForBaseNormal = earliestAquisitionNormal[species] if hasNormal
 
                 evolutions = speciesData.get_evolutions
 
@@ -1108,6 +1122,7 @@ module Compiler
                     evoSpecies = evolutionEntry[0]
                     evoMethod = evolutionEntry[1]
                     param = evolutionEntry[2]
+                    evoLevelThreshold = nil
                     case evoMethod
                     # All method based on leveling up to a certain level
                     when :Level, :LevelDay, :LevelNight, :LevelMale, :LevelFemale, :LevelRain,
@@ -1123,19 +1138,34 @@ module Compiler
                         evoLevelThreshold = getEarliestLevelForItem(param)
                     end
 
-                    earliestLevelForEvolved = [earliestLevelForBase, evoLevelThreshold].max
+                    # Update min acquisition
+                    if hasMin
+                        earliestLevelForEvolvedMin = [earliestLevelForBaseMin, evoLevelThreshold].max
+                        if !earliestAquisitionMin.has_key?(evoSpecies) || earliestAquisitionMin[evoSpecies] > earliestLevelForEvolvedMin
+                            earliestAquisitionMin[evoSpecies] = earliestLevelForEvolvedMin
+                            madeAnyChanges = true
+                        end
+                    end
 
-                    if !earliestAquisition.has_key?(evoSpecies) || earliestAquisition[evoSpecies] > earliestLevelForEvolved
-                        earliestAquisition[evoSpecies] = earliestLevelForEvolved
-                        madeAnyChanges = true
+                    # Update normal acquisition
+                    if hasNormal
+                        earliestLevelForEvolvedNormal = [earliestLevelForBaseNormal, evoLevelThreshold].max
+                        if !earliestAquisitionNormal.has_key?(evoSpecies) || earliestAquisitionNormal[evoSpecies] > earliestLevelForEvolvedNormal
+                            earliestAquisitionNormal[evoSpecies] = earliestLevelForEvolvedNormal
+                            madeAnyChanges = true
+                        end
                     end
                 end
             end
             break unless madeAnyChanges
         end
 
-        earliestAquisition.each do |species, level|
+        earliestAquisitionMin.each do |species, level|
             GameData::Species.get(species).earliest_available = level
+        end
+
+        earliestAquisitionNormal.each do |species, level|
+            GameData::Species.get(species).earliest_available_normal = level
         end
 
         GameData::Species.save

--- a/Plugins/Chasm MasterDex/PokeDex Main/PokemonPokedex_Scene_Searching.rb
+++ b/Plugins/Chasm MasterDex/PokeDex Main/PokemonPokedex_Scene_Searching.rb
@@ -347,6 +347,14 @@ class PokemonPokedex_Scene
     end
 
     def searchByAvailableLevel
+        commands = ["Minimum Level", "Normal Availability", "Cancel"]
+        command = pbMessage(_INTL("What threshold for availability?"), commands, commands.length)
+        return if command == commands.length - 1
+        normal = command == 1
+        return searchByAvailableLevelBase(normal)
+    end
+
+    def searchByAvailableLevelBase(normal = false)
         levelTextInput = pbEnterText(_INTL("Search available by level..."), 0, 3)
         if levelTextInput && levelTextInput != ""
             reversed = levelTextInput[0] == "-"
@@ -360,7 +368,7 @@ class PokemonPokedex_Scene
             dexlist = searchStartingList
             dexlist = dexlist.find_all do |dex_item|
                 next false if autoDisqualifyFromSearch(dex_item[:species])
-                available = dex_item[:data].available_by?(levelCheck)
+                available = dex_item[:data].available_by?(levelCheck, normal)
                 next available ^ reversed # Boolean XOR
             end
             return dexlist


### PR DESCRIPTION
Represents the normally expected available level ignoring sequence breaking etc, with the old parameter now explicitly representing the absolute minimum