### PR TITLE
Replacing battle.foretoldMove instances

### DIFF
--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesAfterMoveUse.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesAfterMoveUse.rb
@@ -36,7 +36,7 @@ BattleHandlers::TargetAbilityAfterMoveUse.add(:MONKEYMISCHIEF,
       next if switched.include?(user.index)
       next unless move.damagingMove?
       next unless user.activatesTargetAbilities?
-      next if battle.foretoldMove
+      next if user.dummy
       move.knockOffItems(target, user, ability: ability, firstItemOnly: true)
   }
 )
@@ -46,7 +46,7 @@ BattleHandlers::TargetAbilityAfterMoveUse.add(:MOONLIGHTER,
       next if switched.include?(user.index)
       next unless move.damagingMove?
       next unless user.activatesTargetAbilities?
-      next if battle.foretoldMove
+      next if user.dummy
       next unless battle.moonGlowing?
       item = user.firstItem
       if move.canStealItem?(user,target, item)

--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesKnockedBelowHalf.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesKnockedBelowHalf.rb
@@ -1,6 +1,6 @@
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:VENGEANCE,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         battle.pbShowAbilitySplash(target, ability)
         user.applyFractionalDamage(1.0 / 4.0) if user.takesIndirectDamage?(true)
         battle.pbHideAbilitySplash(target)
@@ -9,14 +9,14 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:VENGEANCE,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:BRILLIANTFLURRY,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         user.pbLowerMultipleStatSteps(ALL_STATS_1, target, ability: ability)
     }
 )
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:STICKYMOLD,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.leeched?
         battle.pbShowAbilitySplash(target, ability)
         user.applyLeeched(target) if user.canLeech?(target, true)
@@ -26,7 +26,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:STICKYMOLD,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:MOISTSKIN,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.waterlogged?
         battle.pbShowAbilitySplash(target, ability)
         user.applyWaterlog(target) if user.canWaterlog?(target, true)
@@ -48,7 +48,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:EMERGENCYPOWER,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:MALICE,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.effectActive?(:Curse)
         battle.pbShowAbilitySplash(target, ability)
         user.applyEffect(:Curse)
@@ -58,7 +58,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:MALICE,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:SWORDBREAKER,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.effectActive?(:Fracture)
         battle.pbShowAbilitySplash(target, ability)
         user.applyEffect(:Fracture, applyEffectDurationModifiers(DEFAULT_FRACTURE_DURATION, target))
@@ -68,7 +68,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:SWORDBREAKER,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:KARMA,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.effectActive?(:Jinxed)
         battle.pbShowAbilitySplash(target, ability)
         user.applyEffect(:Jinxed, applyEffectDurationModifiers(DEFAULT_JINX_DURATION, target))
@@ -78,7 +78,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:KARMA,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:DREAMYHAZE,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next unless user.canSleep?(target, true)
         next if user.effectActive?(:Yawn)
         battle.pbShowAbilitySplash(target, ability)
@@ -95,7 +95,7 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:SUDDENTURN,
 
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:SUGARCOATED,
     proc { |ability, target, user, move, _switched, battle|
-        next if battle.foretoldMove
+        next if user.dummy
         next if user.effectActive?(:SugarRush)
         battle.pbShowAbilitySplash(target, ability)
         user.applyEffect(:SugarRush, applyEffectDurationModifiers(DEFAULT_SUGAR_RUSH_DURATION, target))

--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/UserAbilitiesEndOfMove.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/UserAbilitiesEndOfMove.rb
@@ -233,7 +233,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:TENEBROUSCANTER,
 
 BattleHandlers::UserAbilityEndOfMove.add(:MAGICIAN,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       targets.each do |b|
           b.eachItem do |item|
@@ -265,7 +265,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:DEEPSTING,
 
 BattleHandlers::UserAbilityEndOfMove.add(:GILD,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       targets.each do |b|
           next unless b.hasAnyItem?
@@ -304,7 +304,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:DAUNTLESS,
 
 BattleHandlers::UserAbilityEndOfMove.add(:POWERLIFTER,
   proc { |ability, user, targets, move, battle, switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.physicalMove?
       move.forceOutTargets(user, targets, switchedBattlers, substituteBlocks: true, random: false, ability: ability)
   }
@@ -312,7 +312,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:POWERLIFTER,
 
 BattleHandlers::UserAbilityEndOfMove.add(:FLUSTERFLOCK,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       hitAnything = false
       targets.each do |b|
@@ -331,7 +331,7 @@ BattleHandlers::UserAbilityEndOfMove.copy(:FLUSTERFLOCK, :HEADACHE)
 
 BattleHandlers::UserAbilityEndOfMove.add(:DYNAMO,
   proc { |ability, user, _targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next if move.damagingMove?
       next if user.effectActive?(:EnergyCharge)
       battle.pbShowAbilitySplash(user, ability)
@@ -343,7 +343,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:DYNAMO,
 
 BattleHandlers::UserAbilityEndOfMove.add(:MIDNIGHTOIL,
   proc { |ability, user, _targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next if move.damagingMove?
       next unless battle.moonGlowing?
       battle.pbShowAbilitySplash(user, ability)
@@ -354,7 +354,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:MIDNIGHTOIL,
 
 BattleHandlers::UserAbilityEndOfMove.add(:ICEQUEEN,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next unless battle.icy?
       user.pbRecoverHPFromMultiDrain(targets, 0.50, user:user, ability: ability)
@@ -363,7 +363,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:ICEQUEEN,
 
 BattleHandlers::UserAbilityEndOfMove.add(:ASTRALHARVEST,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next unless battle.eclipsed?
       user.pbRecoverHPFromMultiDrain(targets, 0.50, user:user, ability: ability)
@@ -372,7 +372,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:ASTRALHARVEST,
 
 BattleHandlers::UserAbilityEndOfMove.add(:SILVERSENSE,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       user.pbRecoverHPFromMultiDrain(targets, 0.50, user:user, ability: ability, onlyCriticalDamage: true)
   }
@@ -380,7 +380,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:SILVERSENSE,
 
 BattleHandlers::UserAbilityEndOfMove.add(:TORPORSAP,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       asleepTargets = []
       targets.each do |target|
@@ -394,7 +394,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:TORPORSAP,
 
 BattleHandlers::UserAbilityEndOfMove.add(:VICIOUSCYCLE,
   proc { |ability, user, targets, move, battle, _switchedBattlers, aiCheck|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next unless move.calcType == :DRAGON
       # AI learns ability if move spreads or drain happens
@@ -405,7 +405,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:VICIOUSCYCLE,
 
 BattleHandlers::UserAbilityEndOfMove.add(:HORDETACTICS,
   proc { |ability, user, targets, move, battle, _switchedBattlers, aiCheck|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next unless move.calcType == :NORMAL
       # AI learns ability if move spreads or drain happens
@@ -441,7 +441,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:COREPROVENANCE,
 
 BattleHandlers::UserAbilityEndOfMove.add(:FEELTHEBURN,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next if user.burned?
       hitAnything = false
@@ -459,7 +459,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:FEELTHEBURN,
 
 BattleHandlers::UserAbilityEndOfMove.add(:COLDCALCULATION,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       next if user.frostbitten?
       hitAnything = false
@@ -477,7 +477,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:COLDCALCULATION,
 
 BattleHandlers::UserAbilityEndOfMove.add(:IRREFUTABLE,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       nveHits = 0
       targets.each do |b|
@@ -492,7 +492,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:IRREFUTABLE,
 
 BattleHandlers::UserAbilityEndOfMove.add(:OVERTHINKING,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.specialMove?
       hitAnything = false
       targets.each do |b|
@@ -507,7 +507,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:OVERTHINKING,
 
 BattleHandlers::UserAbilityEndOfMove.add(:FUELHUNGRY,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       hitAnything = false
       targets.each do |b|
@@ -552,7 +552,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:BELLOWER,
 
 BattleHandlers::UserAbilityEndOfMove.add(:VANDAL,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       clothingItemProc = proc do |item|
         GameData::Item.get(item).is_clothing?
@@ -565,7 +565,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:VANDAL,
 
 BattleHandlers::UserAbilityEndOfMove.add(:STUPEFYING,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       targets.each do |target|
         next unless target.knockedBelowHalf?
@@ -576,7 +576,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:STUPEFYING,
 
 BattleHandlers::UserAbilityEndOfMove.add(:FATIGUED,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       hitAnything = false
       targets.each do |b|
@@ -591,7 +591,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:FATIGUED,
 
 BattleHandlers::UserAbilityEndOfMove.add(:HYBRIDFIGHTER,
   proc { |ability, user, targets, move, battle, switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.damagingMove?
       hitAnything = false
       targets.each do |b|
@@ -649,7 +649,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:HYBRIDFIGHTER,
 
 BattleHandlers::UserAbilityEndOfMove.add(:OFFENSIVE,
   proc { |ability, user, targets, move, battle, switchedBattlers|
-    next if battle.foretoldMove
+    next if user.dummy
     next unless move.damagingMove?
     next unless user.firstTurn?
     targets.each do |b|
@@ -689,7 +689,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:TANGLINGVINES,
 
 BattleHandlers::UserAbilityEndOfMove.add(:FRIGHTENINGFANGS,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.bitingMove?
       targets.each do |b|
           next if b.fainted?

--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/On Hit/TargetAbilitiesOnHit.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/On Hit/TargetAbilitiesOnHit.rb
@@ -66,6 +66,7 @@ BattleHandlers::TargetAbilityOnHit.add(:GRAVITYWELL,
 
 BattleHandlers::TargetAbilityOnHit.add(:GOOEY,
   proc { |ability, user, target, move, _battle, aiCheck, aiNumHits|
+        next if user.dummy
         next unless move.physicalMove?
         if aiCheck
             ret = 0
@@ -80,6 +81,7 @@ BattleHandlers::TargetAbilityOnHit.add(:GOOEY,
 
 BattleHandlers::TargetAbilityOnHit.add(:SICKENING,
   proc { |ability, user, target, move, _battle, aiCheck, aiNumHits|
+        next if user.dummy
         next unless move.specialMove?
         if aiCheck
             ret = 0

--- a/Plugins/Chasm Battle/Items/BattleHandlers/On Hit/TargetItemsOnHit.rb
+++ b/Plugins/Chasm Battle/Items/BattleHandlers/On Hit/TargetItemsOnHit.rb
@@ -32,7 +32,7 @@ BattleHandlers::TargetItemOnHit.add(:ROWAPBERRY,
 
 BattleHandlers::TargetItemOnHit.add(:ROCKYHELMET,
   proc { |item, user, target, move, battle, aiCheck, aiNumHits|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless move.physicalMove?
       next unless user.takesIndirectDamage?
       next -10 * aiNumHits if aiCheck
@@ -44,7 +44,7 @@ BattleHandlers::TargetItemOnHit.add(:ROCKYHELMET,
 
 BattleHandlers::TargetItemOnHit.add(:HIVISJACKET,
   proc { |item, user, target, move, battle, aiCheck, aiNumHits|
-      next if battle.foretoldMove
+      next if user.dummy
       next if move.physicalMove?
       next unless user.takesIndirectDamage?
       next -10 * aiNumHits if aiCheck
@@ -113,7 +113,7 @@ BattleHandlers::TargetItemOnHit.add(:WEAKNESSPOLICY,
 
 BattleHandlers::TargetItemOnHit.add(:STICKYBARB,
   proc { |item, user, target, move, battle, aiCheck, aiNumHits|
-      next if battle.foretoldMove
+      next if user.dummy
       next unless user.canAddItem?(item)
       next -20 if aiCheck 
       user.giveItem(item)


### PR DESCRIPTION
with user.dummy.
This makes it so Foretold moves only don't trigger ability/item effects, if the user of the move swapped out.