### PR TITLE
Team Code Format Rework

### DIFF
--- a/Plugins/Chasm Other/Utilities/Utilities_TeamCode.rb
+++ b/Plugins/Chasm Other/Utilities/Utilities_TeamCode.rb
@@ -73,8 +73,8 @@ def encode_team(party)
   version_u16 |= (version_split[2].to_i & 0x1f) << VERSION_PATCH_SHIFT
 
   data = [
-    [poke_party_encoding_u8, BytesRequired::U8],
     [poke_party_version_u8, BytesRequired::U8],
+    [poke_party_encoding_u8, BytesRequired::U8],
     [version_u16, BytesRequired::U16]
   ]
 


### PR DESCRIPTION
Majority of credit to Cincidial over at https://github.com/Pokemon-Tectonic-Team/tectonic-tools/pull/366, I just ported it to Ruby.

This new team code format encodes strings directly instead of trying to maintain a consistent indexing scheme, making it more resistant to updates and edge cases. Basic testing shows that it should be functional.