### PR TITLE
Fix imported Pokemon appearing with wrong stats

### DIFF
--- a/Plugins/Chasm Other/Utilities/Utilities_TeamCode.rb
+++ b/Plugins/Chasm Other/Utilities/Utilities_TeamCode.rb
@@ -147,6 +147,9 @@ def decode_stats(mon, buffer)
   mon.ev[:SPECIAL_DEFENSE] = style_sdef
   mon.ev[:SPEED] = style_speed
   mon.level = level
+
+  # force stats to recalculate
+  mon.calc_stats
 end
 
 def decode_team(code)


### PR DESCRIPTION
Force recalculation after setting stats. Note that stats would often self-correct if interfaced with, so this is mostly a visual bug