### PR TITLE
Rename "Test Trait" to "Experimental"

### DIFF
--- a/Plugins/-- MOD TEMPLATE --/traits.txt
+++ b/Plugins/-- MOD TEMPLATE --/traits.txt
@@ -1,1 +1,1 @@
-DEBUG_TESTTRAIT,Test Trait
+DEBUG_TESTTRAIT,Experimental


### PR DESCRIPTION
Since it can show up for casual players if they play in debug, and it doesn't have a description field to make its purpose obvious, it would be best if the name was unobtrusive.