### PR TITLE
Fix Avatar of Linoone getting stuck on unstealable items

### DIFF
--- a/Plugins/Chasm Battle/AI/AI_Boss_Classes.rb
+++ b/Plugins/Chasm Battle/AI/AI_Boss_Classes.rb
@@ -499,6 +499,10 @@ class PokeBattle_AI_LINOONE < PokeBattle_AI_Boss
         super
         @warnedIFFMove.add(:COVET, {
             :condition => proc { |_move, user, target, _battle|
+                # if we know the target's item, only use if it's stealable
+                target.eachAIKnownItem do |item|
+                    next false if target.unlosableItem?(item)
+                end
                 next target.hasAnyItem?
             },
             :warning => proc { |_move, user, targets, _battle|


### PR DESCRIPTION
There are a couple of caveats with this PR

Firstly, I'm not sure if there should be more thorough checks for stealability. There's a helper method for canStealItem, but it only exists on Moves. 

Secondly, it feels like Avatar AI in general should probably be moved to content, but this is where the code is for now, so I've made it an engine PR. We can shift it over later, or do so first and I'll remake this PR on Content.

Thirdly, I haven't tested this in battle yet. Partially because it's on Engine, partially because I'm in a coding mood rather than a testing mood and just trying to swat down bug report threads.