### PR TITLE
Non kill outscore fix

### DIFF
--- a/PBS/trainers.txt
+++ b/PBS/trainers.txt
@@ -1,11 +1,5 @@
 ﻿# See the documentation on the wiki to learn how to edit this file.
 #-------------------------------
-[YOUNGSTER,LuckHerbTest]
-Pokemon = SMEARGLE,70
-    Moves = THUNDERBOLT,ICEBEAM,FLAMETHROWER,AERIALACE
-    AbilityIndex = 1 # Technician
-    Item = LUCKHERB
-#-------------------------------
 [BATTLEGIRL,Tester]
 Pokemon = SLAKING,70
     Moves = TACKLE

--- a/PBS/trainers.txt
+++ b/PBS/trainers.txt
@@ -1,5 +1,11 @@
 ﻿# See the documentation on the wiki to learn how to edit this file.
 #-------------------------------
+[YOUNGSTER,LuckHerbTest]
+Pokemon = SMEARGLE,70
+    Moves = THUNDERBOLT,ICEBEAM,FLAMETHROWER,AERIALACE
+    AbilityIndex = 1 # Technician
+    Item = LUCKHERB
+#-------------------------------
 [BATTLEGIRL,Tester]
 Pokemon = SLAKING,70
     Moves = TACKLE

--- a/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
@@ -1,4 +1,6 @@
 class PokeBattle_AI
+    KILL_SCORE = 250 
+
     def pbChooseMovesTrainer(idxBattler, choices)
         user = @battle.battlers[idxBattler]
         owner = @battle.pbGetOwnerFromBattlerIndex(user.index)
@@ -306,9 +308,9 @@ class PokeBattle_AI
         # so they never outscore a KO move (250) on damage alone
         if !willFaint && damagingMove
             scaledTargetEffect = targetAffectingEffectScore.floor
-            if damageScore + scaledTargetEffect > 249
-                echoln("\t[MOVE SCORING] Capping non-KO damage + target effect score from #{damageScore + scaledTargetEffect} to 249")
-                effectScore -= scaledTargetEffect - (249 - damageScore)
+            if damageScore + scaledTargetEffect >= KILL_SCORE
+                echoln("\t[MOVE SCORING] Capping non-KO damage + target effect score from #{damageScore + scaledTargetEffect} to #{KILL_SCORE - 1}")
+                effectScore -= scaledTargetEffect - (KILL_SCORE - damageScore - 1)
             end
         end
 
@@ -409,7 +411,7 @@ class PokeBattle_AI
         willFaint = false
         if realDamage >= target.hp
             realDamage = target.hp
-            damageScore = 250
+            damageScore = KILL_SCORE 
             willFaint = true
         else
             # Only care about KO thresholds

--- a/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
@@ -280,12 +280,6 @@ class PokeBattle_AI
                 targetAffectingEffectScore = move.getTargetAffectingEffectScore(user, target)
             end
             damageBasedEffectScore = move.getDamageBasedEffectScore(user, target, damageDealt)
-            # Cap damage + target-affecting effect score at 249 for non-KO moves
-            # so they never outscore a KO move (250) on damage alone
-            if !willFaint && damagingMove && damageScore + targetAffectingEffectScore > 249
-                echoln("\t[MOVE SCORING] Capping non-KO damage + target effect score from #{damageScore + targetAffectingEffectScore} to 249")
-                targetAffectingEffectScore = 249 - damageScore
-            end
             effectScore += regularEffectScore
             effectScore += faintEffectScore
             effectScore += targetAffectingEffectScore
@@ -304,8 +298,19 @@ class PokeBattle_AI
             factor = (realProcChance / 100.0)
             echoln("\t[MOVE SCORING] #{user.pbThis} multiplies #{move.id}'s effect score of #{effectScore} by #{factor} based on effect chance")
             effectScore *= factor
+            targetAffectingEffectScore *= factor
         end
         effectScore = effectScore.floor
+
+        # Cap damage + target-affecting effect score at 249 for non-KO moves
+        # so they never outscore a KO move (250) on damage alone
+        if !willFaint && damagingMove
+            scaledTargetEffect = targetAffectingEffectScore.floor
+            if damageScore + scaledTargetEffect > 249
+                echoln("\t[MOVE SCORING] Capping non-KO damage + target effect score from #{damageScore + scaledTargetEffect} to 249")
+                effectScore -= scaledTargetEffect - (249 - damageScore)
+            end
+        end
 
         # Combine
         score = damageScore + triggersScore + effectScore

--- a/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
@@ -280,6 +280,12 @@ class PokeBattle_AI
                 targetAffectingEffectScore = move.getTargetAffectingEffectScore(user, target)
             end
             damageBasedEffectScore = move.getDamageBasedEffectScore(user, target, damageDealt)
+            # Cap damage + target-affecting effect score at 249 for non-KO moves
+            # so they never outscore a KO move (250) on damage alone
+            if !willFaint && damagingMove && damageScore + targetAffectingEffectScore > 249
+                echoln("\t[MOVE SCORING] Capping non-KO damage + target effect score from #{damageScore + targetAffectingEffectScore} to 249")
+                targetAffectingEffectScore = 249 - damageScore
+            end
             effectScore += regularEffectScore
             effectScore += faintEffectScore
             effectScore += targetAffectingEffectScore


### PR DESCRIPTION
Caps targetAffectingEffectScore (after random chance modification) to 249 to avoid outscoring damage value for a kill

Resolves #71 