### PR TITLE
Fix Finale abilities to check fainting instead of ableness

### DIFF
--- a/Plugins/Chasm Battle/Battler/Battler_Queries.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Queries.rb
@@ -684,7 +684,7 @@ class PokeBattle_Battler
             return !hasAlly?
         end
         return false if fainted?
-        return @battle.pbGetOwnerFromBattlerIndex(@index).able_pokemon_count == 1
+        return @battle.pbGetOwnerFromBattlerIndex(@index).alive_pokemon_count == 1
     end
 
     def protectedAgainst?(user, move)

--- a/Plugins/Chasm Game Data/Trainers and Player/Trainer.rb
+++ b/Plugins/Chasm Game Data/Trainers and Player/Trainer.rb
@@ -97,6 +97,14 @@ class Trainer
       @party.each { |p| ret += 1 if p && p.able? }
       return ret
     end
+
+    # Counts party members that are alive (HP > 0, not afraid, not egg),
+    # regardless of ability-based restrictions like PACIFIST or UnableByDefault.
+    def alive_pokemon_count
+      ret = 0
+      @party.each { |p| ret += 1 if p && !p.fainted? }
+      return ret
+    end
   
     def party_full?
       return party_count >= Settings::MAX_PARTY_SIZE


### PR DESCRIPTION
Should not trigger if you have alive but unusable Pokemon such as Zamazenta
Close #82 