### PR TITLE
Preserve important cached data on loading save

### DIFF
--- a/Plugins/Chasm Game Processing/StartGame.rb
+++ b/Plugins/Chasm Game Processing/StartGame.rb
@@ -10,6 +10,7 @@ module Game
       $data_common_events = load_data('Data/CommonEvents.rxdata')
       $data_system        = load_data('Data/System.rxdata')
       pbLoadBattleAnimations
+      pbLoadMoveToAnim
       GameData.load_all
       map_file = format('Data/Map%03d.rxdata', $data_system.start_map_id)
       if $data_system.start_map_id == 0 || !pbRgssExists?(map_file)
@@ -62,7 +63,7 @@ module Game
     def self.load(save_data)
       validate save_data => Hash
       SaveData.load_all_values(save_data)
-      $PokemonTemp = PokemonTemp.new # reset temp data in case we're coming from another save
+      $PokemonTemp.reset_session_data # reset transient state in case we're coming from another save
       self.load_map
       pbAutoplayOnSave
       $game_map.update

--- a/Plugins/Chasm Other/Globals/PokemonTemp.rb
+++ b/Plugins/Chasm Other/Globals/PokemonTemp.rb
@@ -40,12 +40,41 @@ class PokemonTemp
     attr_accessor :currentDexSearch
   
     def initialize
+      reset_session_data
+    end
+
+    # Resets only session-specific state. Called on save load to avoid carrying
+    # transient state (e.g. follower sprites, encounter flags) across saves while
+    # preserving loaded GameData caches so they don't have to be deserialized again.
+    def reset_session_data
       @menuLastChoice         = 0
       @keyItemCalling         = false
       @hiddenMoveEventCalling = false
+      @bicycleCalling         = nil
       @begunNewGame           = false
       @miniupdate             = false
+      @waitingTrainer         = nil
+      @darknessSprite         = nil
+      @lastbattle             = nil
+      @flydata                = nil
+      @surfJump               = nil
+      @endSurf                = nil
       @forceSingleBattle      = false
+      @encounterTriggered     = nil
+      @encounterType          = nil
+      @evolutionLevels        = nil
+      @dependentEvents        = nil  # follower data; lazy-reinitialised on next access
+      @batterywarning         = nil
+      @cueBGM                 = nil
+      @cueFrames              = nil
+      @navigationRow          = nil
+      @navigationColumn       = nil
+      @currentDexSearch       = nil
+      @battleRules            = nil
+      @dragonFlames           = nil
+      # GameData caches (battleAnims, moveToAnim, mapInfos, townMapData,
+      # phoneData, speciesShadowMovesets, regionalDexes) are intentionally
+      # preserved so they don't need to be reloaded on every save load.
     end
 
     def dependentEvents


### PR DESCRIPTION
Was previously overzealously wiping everything in an attempt to prevent follower-related crashes. This caused battle animations to have to reload the first time one would play.

In the long-term, it may make sense to separate save-specific temp data and session-wide temp data into different objects.

Close #241 