### PR TITLE
Restore some achievement definitions as stubs

### DIFF
--- a/Plugins/Chasm Achievements/Achievement Definitions/BattleAchievements.rb
+++ b/Plugins/Chasm Achievements/Achievement Definitions/BattleAchievements.rb
@@ -1,0 +1,3 @@
+def checkBattleStateAchievements(battle)
+
+end

--- a/Plugins/Chasm Achievements/Achievement Definitions/CollectionAchievements.rb
+++ b/Plugins/Chasm Achievements/Achievement Definitions/CollectionAchievements.rb
@@ -1,0 +1,18 @@
+def incrementSuccessfulCaptureCount(ball)
+    $PokemonGlobal.capture_counts_per_ball = {} if $PokemonGlobal.capture_counts_per_ball.nil?
+    if $PokemonGlobal.capture_counts_per_ball.key?(ball)
+        $PokemonGlobal.capture_counts_per_ball[ball] += 1
+    else
+        $PokemonGlobal.capture_counts_per_ball[ball] = 1
+    end
+    checkForCapturesWithBallsAchievements unless $battle.is_replayed
+end
+
+def checkForCapturesWithBallsAchievements
+
+end
+
+
+def checkForCaptureAchievements(ball, battle, pkmn)
+
+end


### PR DESCRIPTION
Core parts of engine code call them and it seems useful to leave those hooks in rather than add them only on Content. However the specific achievements are content-specific