### PR TITLE
Improve Cable Club opponent ID input

### DIFF
--- a/Plugins/Chasm Cable Club/[001] Cable Club Client/006_CableClub_UI.rb
+++ b/Plugins/Chasm Cable Club/[001] Cable Club Client/006_CableClub_UI.rb
@@ -388,13 +388,12 @@ class CableClubScreen
     begin
       msg = _ISPRINTF("Opponent's ID (Yours: {1:05d})",$Trainer.public_ID($Trainer.id))
       partner_id = $PokemonGlobal.last_partner_id || ""
-      loop do
-        partner_id = pbEnterText(msg, 5, 5, partner_id)
-        return false if partner_id.empty?
-        if partner_id =~ /^[0-9]{5}$/
-          $PokemonGlobal.last_partner_id = partner_id
-          break
-        end
+      partner_id = pbEnterText(msg, 0, 5, partner_id)
+      if partner_id =~ /^[0-9]{5}$/
+        $PokemonGlobal.last_partner_id = partner_id
+      else
+        pbDisplay(_INTL("Please enter a valid trainer ID of 5 digits."))
+        return false
       end
       pbConnectServer(partner_id)
       raise Connection::Disconnected.new("disconnected")


### PR DESCRIPTION
Instead of requiring 5 characters and looping until the input is valid, it now lets you cancel and rejects invalid inputs, allowing players to not feel trapped in the ID entry screen

One of the two suggestions in #142. The other requires a broader feature addition to text entry at large, so I'll consider it a separate task.