### PR TITLE
fix Immunity dialogue bad var name

### DIFF
--- a/Plugins/Chasm Battle/AI/Trainers AI/Dialogue/DialogueEvents.rb
+++ b/Plugins/Chasm Battle/AI/Trainers AI/Dialogue/DialogueEvents.rb
@@ -284,7 +284,7 @@ dialogue)
     end
 
     def triggerImmunityDialogue(user, target, isImmunityAbility)
-        triggerDialogueOnBattlerAction(user) do |isTrainerOwned, policy, trainer_speaking, dialogue|
+        triggerDialogueOnBattlerAction(target) do |isTrainerOwned, policy, trainer_speaking, dialogue|
             if isTrainerOwned
                 PokeBattle_AI.triggerTrainerPokemonImmuneDialogue(policy, user, target, isImmunityAbility, trainer_speaking,
 dialogue)


### PR DESCRIPTION
immunity dialogue was checking based on the attacker instead of the defender incorrectly, causing it to generally not fire 

now fixed (tested on Lambert and Yezera VI)

along with 147 on Content, resolves 41 on Content as well