### PR TITLE
Allow curses to trigger without the amulet

### DIFF
--- a/Plugins/Chasm Battle/Battle/Battle_StartAndEnd.rb
+++ b/Plugins/Chasm Battle/Battle/Battle_StartAndEnd.rb
@@ -385,7 +385,7 @@ class PokeBattle_Battle
             end
         end
         # Curses apply if at all
-        if @opponent && $PokemonGlobal.tarot_amulet_active
+        if @opponent
             @statItemsAreMetagameRevealed = false
             @opponent.each do |opponent|
                 opponent.policies.each do |policy|


### PR DESCRIPTION
Most curses are still only on fights battled with the amulet on, this is just to allow edge-cases like the "Force Perfect" curse for AP Rafael

As a side-effect, the "METAGAMES_STAT_ITEMS" policy now applies regardless of amulet status, which seems more correct anyway.