### PR TITLE
Fix timing issues with HITANDRUN

### DIFF
--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/UserAbilitiesEndOfMove.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/UserAbilitiesEndOfMove.rb
@@ -952,8 +952,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:HITANDRUN,
   proc { |ability, user, targets, move, battle, _switchedBattlers|
       next if user.dummy
       next unless move.damagingMove?
-      if (targets.any? { |b| b.knockedBelowHalf? })
-        next battle.triggeredSwitchOut(user.index, ability: ability)
-      end
+      next unless targets.any? { |b| b.knockedBelowHalf? }
+      user.applyEffect(:HitAndRunSwitch)
   }
 )

--- a/Plugins/Chasm Battle/Battler/Battler_UseMove_TriggerEffects.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_UseMove_TriggerEffects.rb
@@ -196,6 +196,15 @@ user.pbThis(true)))
                 user.position.disableEffect(:Kickback)
             end
         end
+        # Hit and Run
+        if user.effectActive?(:HitAndRunSwitch) && !switchedBattlers.include?(user.index)
+            if @battle.triggeredSwitchOut(user.index, ability: :HITANDRUN)
+                user.pbEffectsOnSwitchIn(true)
+                switchedBattlers.push(user.index)
+            else
+                user.disableEffect(:HitAndRunSwitch)
+            end
+        end
         # Some move effects that need to happen here, i.e. U-turn/Volt Switch
         # switching, Baton Pass switching, Parting Shot switching, Relic Song's form
         # changing, Fling/Natural Gift consuming item.

--- a/Plugins/Chasm Battle/Effects/EffectDefinitions/BattlerEffects.rb
+++ b/Plugins/Chasm Battle/Effects/EffectDefinitions/BattlerEffects.rb
@@ -2190,6 +2190,13 @@ GameData::BattleEffect.register_effect(:Battler, {
 })
 
 GameData::BattleEffect.register_effect(:Battler, {
+    :id => :HitAndRunSwitch,
+    :real_name => "Hit and Run Switch",
+    :info_displayed => false,
+    :resets_eor => true,
+})
+
+GameData::BattleEffect.register_effect(:Battler, {
     :id => :MisdirectingFogSelected,
     :real_name => "Selected for Misdirecting Fog Switch",
 })


### PR DESCRIPTION
Should now wait to switch until after processing held items, and the switched-in Pokemon will properly take hazard damage. Same process as Kickback/Ally Cushion. 
Fix #219
Fix #222