### PR TITLE
Actually fix UnableByDefault abilities in wild battles

### DIFF
--- a/Plugins/Chasm Battle/Battle/PokeBattle_Battle.rb
+++ b/Plugins/Chasm Battle/Battle/PokeBattle_Battle.rb
@@ -132,11 +132,7 @@ class PokeBattle_Battle
     def pbAbleCount(idxBattler = 0)
         party = pbParty(idxBattler)
         count = 0
-        wild_side = wildBattle? && idxBattler % 2 == 1
-        party.each_with_index do |pkmn, i|
-            able_params = wild_side ? GameData::Ability.getByFlag("UnableByDefault") : getAbleParametersByBattlerIndex(i, idxBattler)
-            count += 1 if pkmn && pkmn.able?(false, able_params)
-        end
+        party.each_with_index { |pkmn, i| count += 1 if pkmn && pkmn.able?(false, getAbleParametersByBattlerIndex(i, idxBattler)) }
         return count
     end
 
@@ -145,10 +141,8 @@ class PokeBattle_Battle
         inBattleIndices = []
         eachSameSideBattler(idxBattler) { |b| inBattleIndices.push(b.pokemonIndex) }
         count = 0
-        wild_side = wildBattle? && idxBattler % 2 == 1
         party.each_with_index do |pkmn, idxParty|
-            able_params = wild_side ? GameData::Ability.getByFlag("UnableByDefault") : getAbleParametersByBattlerIndex(idxParty, idxBattler)
-            next if !pkmn || !pkmn.able?(false, able_params)
+            next if !pkmn || !pkmn.able?(false, getAbleParametersByBattlerIndex(idxParty, idxBattler))
             next if inBattleIndices.include?(idxParty)
             count += 1
         end
@@ -172,10 +166,7 @@ class PokeBattle_Battle
                 idxTeam += 1
                 nextStart = (idxTeam < partyStarts.length - 1) ? partyStarts[idxTeam + 1] : party.length
             end
-            # Wild Pokémon appear in battle regardless of UnableByDefault restrictions,
-            # so bypass that check when counting the wild side's participants.
-            able_params = (wildBattle? && side == 1) ? GameData::Ability.getByFlag("UnableByDefault") : getAbleParameters(i, side, pbGetOwnerIndexFromBattlerIndex(side))
-            next if !pkmn || !pkmn.able?(false, able_params)
+            next if !pkmn || !pkmn.able?(false, getAbleParameters(i, side, pbGetOwnerIndexFromBattlerIndex(side)))
             ret[idxTeam] = 0 unless ret[idxTeam]
             ret[idxTeam] += 1
         end
@@ -240,6 +231,8 @@ class PokeBattle_Battle
     end
 
     def getAbleParameters(idxPokemon, side, idxTrainer)
+        # Wild Pokémon appear in battle unconditionally — all UnableByDefault restrictions are bypassed.
+        return GameData::Ability.getByFlag("UnableByDefault") if wildBattle? && side == 1
         ret = []
         ret.push(:EXOSPHERICDESCENT) if isLastAboveHalfHealthInTeam?(idxPokemon, side, idxTrainer)
         ret.push(:SLUMBERINGSWORD) if @field.effectActive?(:SlumberingSwordReady)

--- a/Plugins/Chasm Battle/Battler/Battler_Properties.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Properties.rb
@@ -63,6 +63,8 @@ class PokeBattle_Battler
 
     def refusesToFight?
         return true if afraid?
+        # Wild Pokémon are already in the battle and should never refuse to fight.
+        return false if @battle.wildBattle? && pbOwnSide.index == 1
         idxTrainer = @battle.pbGetOwnerIndexFromBattlerIndex(index)
         eachActiveAbility(true, ignoreGas:true) do |ability|
             return true if BattleHandlers.triggerForbidsUserSwitchInAbility(


### PR DESCRIPTION
Revert previous piecemeal patches
Instead completely bypass UnableByDefault abilities for Wild Pokemon, always treating them as eligible to enter battle 
Similarly, make Wild Pokemon unable to "refuse to battle", which was causing the lack of interaction 
Fix #286