### PR TITLE
Improve handling of duplicate IDs in Cable Club

### DIFF
--- a/Plugins/Chasm Cable Club/[001] Cable Club Client/006_CableClub_UI.rb
+++ b/Plugins/Chasm Cable Club/[001] Cable Club Client/006_CableClub_UI.rb
@@ -412,6 +412,9 @@ class CableClubScreen
       when "peer disconnected"
         pbDisplay(_INTL("I'm sorry, the other trainer has disconnected."))
         return true
+      when "peer already connected"
+        pbDisplay(_INTL("I'm sorry, that trainer connected to someone else with the same ID as you."))
+        return false
       when "invalid version"
         pbDisplay(_INTL("I'm sorry, your game version is out of date compared to the Cable Club."))
         return false

--- a/cable_club_v19.py
+++ b/cable_club_v19.py
@@ -213,6 +213,7 @@ class Server:
                             and st_.state.peer_id == public_id(id)
                         ):
                             self.connect(s, s_)
+                            break
 
     # Finding, simply ignore messages until the peer connects.
     def handle_finding(self, s, st, message):

--- a/cable_club_v19.py
+++ b/cable_club_v19.py
@@ -205,15 +205,18 @@ class Server:
                         peer_id, name, id, ttype, party, win_text, lose_text
                     )
                     # Is the peer already waiting?
-                    for s_, st_ in self.clients.items():
-                        if (
-                            st is not st_
-                            and isinstance(st_.state, Finding)
-                            and public_id(st_.state.id) == peer_id
-                            and st_.state.peer_id == public_id(id)
-                        ):
-                            self.connect(s, s_)
-                            break
+                    candidates = [
+                        s_
+                        for s_, st_ in self.clients.items()
+                        if st is not st_
+                        and isinstance(st_.state, Finding)
+                        and public_id(st_.state.id) == peer_id
+                        and st_.state.peer_id == public_id(id)
+                    ]
+                    if candidates:
+                        self.connect(s, candidates[0])
+                        for s_ in candidates[1:]:
+                            self.disconnect(s_, "peer already connected")
 
     # Finding, simply ignore messages until the peer connects.
     def handle_finding(self, s, st, message):


### PR DESCRIPTION
Fix #316 

Player A1 and A2 both search for ID B. Player B searches for ID A.
Previous behaviour: A1 gets a server error, A2 stays searching, B sees A1 disconnect
New behaviour: A1 and B connect, A2 gets an informative error message
Cause: In trying to process A2, server was processing A1 as a pending connection after it already transitioned to a connected one, and they don't have the same properties