### PR TITLE
Adjust waypoint display on region map to account for event position on that map

### DIFF
--- a/Plugins/Chasm Graphics and UI/Menus/Waypoints.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Waypoints.rb
@@ -12,6 +12,7 @@ class WaypointsTracker
 	def initialize()
 		@activeWayPoints = {}
 		@legendsMaterialized = []
+		resetMapPositionHash
 	end
 
 	def overwriteWaypoint(waypointName,event,newName=nil)
@@ -23,18 +24,26 @@ class WaypointsTracker
 
 	def setWaypoint(waypointName,mapID,wayPointInfo)
 		@activeWayPoints[waypointName] = [mapID,wayPointInfo]
+		resetMapPositionHash
 	end
 
 	def deleteWaypoint(waypointName)
 		@activeWayPoints.delete(waypointName)
+		resetMapPositionHash
 	end
 
 	def deleteAllWaypoints
 		@activeWayPoints = {}
+		resetMapPositionHash
+	end
+
+	def resetMapPositionHash
+		@positionHash = nil
 	end
 
 	def mapPositionHash
-		return generateMapPositionHash
+		generateMapPositionHash if @positionHash.nil?
+		return @positionHash
 	end
 
 	def generateMapPositionHash
@@ -43,10 +52,67 @@ class WaypointsTracker
 		activeWayPoints.each do |waypointName,waypointInfo|
 			mapID = waypointInfo[0]
 			next unless mapInfos[mapID] # Skip map if it somehow doesn't exist anymore
-			displayedPosition = getDisplayedPositionOfGameMap(mapID)
+			eventID = waypointInfo[1]
+			mapInfo = mapInfos[mapID]
+			event = getEventByID(eventID,mapID)
+			next if event.nil?
+			eventX = event.x
+			eventY = event.y
+			
+			# Get the most relevant map metadata
+			recursiveMapID = mapID
+			displayedPosition = nil
+			while recursiveMapID >= 1 && displayedPosition.nil?
+				map_metadata = GameData::MapMetadata.try_get(recursiveMapID)
+				if map_metadata.nil? || map_metadata.town_map_position.nil?
+					recursiveMapID = mapInfos[recursiveMapID].parent_id
+				else
+				  	displayedPosition = map_metadata.town_map_position
+				end
+			end
+
+			if displayedPosition.nil?
+				echoln("ERROR: Cannot figure out where to place waypoint #{waypointName} on map.")
+				next
+			end
+
+			mapX    = displayedPosition[1]
+			mapY    = displayedPosition[2]
+
+			# Shift display position based on event position on map
+            unless map_metadata.nil?
+                mapsize = map_metadata.town_map_size
+                if !mapsize.nil? && mapsize[0] && mapsize[0] > 0
+                    sqwidth  = mapsize[0]
+                    sqheight = (mapsize[1].length * 1.0 / mapsize[0]).ceil
+
+					mapWidth, mapHeight = MapFactoryHelper.getMapDims(mapID)
+
+                    mapX += (eventX * sqwidth / mapWidth).floor if sqwidth > 1
+                    mapY += (eventY * sqheight / mapHeight).floor if sqheight > 1
+                end
+            end
+
+			displayedPosition[1] = mapX
+			displayedPosition[2] = mapY
+
 			mapPositionHash[waypointName] = displayedPosition 
 		end
-		return mapPositionHash
+
+		dupes = mapPositionHash.keys.group_by do |waypointName|
+			mapPositionHash[waypointName]
+		end.select do |k, v|
+			v.length > 1
+		end.map(&:last)
+
+		dupes.each do |dupeGroup|
+			echoln("Multiple waypoints are rendering on the same map tile!")
+			dupeGroup.each do |dupe|
+				echoln(dupe)
+			end
+		end
+
+		@positionHash = mapPositionHash
 	end
 	
 	def getWaypointAtMapPosition(x,y)
@@ -64,6 +130,7 @@ class WaypointsTracker
 		else
 			@activeWayPoints[waypointName] = [event.map_id,event.id]
 		end
+		resetMapPositionHash
 	end
 
 	def summonPokemonFromWaypoint(avatarSpecies,waypointEvent)
@@ -166,12 +233,13 @@ class WaypointsTracker
 		end
 	end
 
-    def checkForWaypointsAchievement
+    def checkForWaypointsAchievement(listMissing = false)
         unlockedAll = true
         $waypoints_tracker.eachWaypoint do |event, mapID, waypointName|
             next if @activeWayPoints.has_key?(waypointName)
             unlockedAll = false
-            break
+            break unless listMissing
+			echoln("Missing waypoint: #{waypointName}, #{event.name} (#{event.id}), #{mapID}")
         end
         return unless unlockedAll
         unlockAchievement(:UNLOCK_ALL_WAYPOINTS)


### PR DESCRIPTION
E.g. to move it to the correct section of a multi-tile map, in the same way that the player head does

Also, the mapPositionHash is now cached, so its not regenerated literally every time its used, but only when a waypoint is added or removed.

Also, moved a small change to the achievement checker to Engine since it was only on Tectonic-Content.