### PR TITLE
Fix follower jank

### DIFF
--- a/Plugins/Chasm Game Processing/Game/Dependent Events/DependentEvents.rb
+++ b/Plugins/Chasm Game Processing/Game/Dependent Events/DependentEvents.rb
@@ -38,7 +38,10 @@ class PokemonGlobalMetadata
 end
 
 def pbTestPass(follower, x, y, _direction = nil)
-    return $MapFactory.isPassableStrict?(follower.map.map_id, x, y, follower)
+	# removed line to fix follower jank:
+    # return $MapFactory.isPassableStrict?(follower.map.map_id, x, y, follower)
+	# added line to fix follower jank:
+	return true
 end
 
 # Same map only
@@ -296,7 +299,7 @@ class DependentEvents
             # Fall back on making current position into leader's position
             mapTile ||= [leader.map.map_id, leader.x, leader.y]
             follower = moveFollowerToDifferentMap(follower, leader, mapTile) if follower.map.map_id != mapTile[0]
-            moveFollowerToNearbySpot(follower, leader, mapTile)
+            moveFollowerToNearbySpot(follower, leader, mapTile, true)
         end
     end
 
@@ -340,7 +343,7 @@ class DependentEvents
         return [xDistance, yDistance].max
     end
 
-    def moveFollowerToNearbySpot(follower, leader, _mapTile)
+    def moveFollowerToNearbySpot(follower, leader, _mapTile, careAboutCollision = false)
         # Follower is on same map as leader
         newPosX = leader.x
         newPosY = leader.y
@@ -360,7 +363,12 @@ class DependentEvents
         end
 
         nearbySpotOffsets.each do |spot|
-            passable = $MapFactory.isPassable?(leader.map.map_id, leader.x + spot[0], leader.y + spot[1], follower)
+			passable = nil
+			if careAboutCollision
+				passable = $MapFactory.isPassable?(leader.map.map_id, leader.x + spot[0], leader.y + spot[1], follower)
+			else
+				passable = true
+			end
             next unless passable
             newPosX += spot[0]
             newPosY += spot[1]


### PR DESCRIPTION
Circumvents logic forcing followers to perform collision detection, which eliminates the problem known as "follower jank" in which they would be unable to follow the player while moving next to collision sometimes.

The underlying assumption is that the follower should be moving into the tile where the player was previously standing, and because the player was able to get there, it is necessarily a passable tile. This logic doesn't hold right when you enter a map (because the tile the player entered from is not necessarily passable), so collision detection is still performed when moving between maps.

Fixes #351.