### PR TITLE
Fix Black Herb loop

### DIFF
--- a/Plugins/Chasm Battle/Items/BattleHandlers/Move End/EndOfMoveStatRestoreItems.rb
+++ b/Plugins/Chasm Battle/Items/BattleHandlers/Move End/EndOfMoveStatRestoreItems.rb
@@ -38,9 +38,10 @@ BattleHandlers::EndOfMoveStatRestoreItem.add(:BLACKHERB,
             battle.pbDisplay(_INTL("{1} weaponized its stat changes using its {2}!",
                battler.pbThis, itemName))
         end
+        battler.pbHeldItemTriggered(item, !forced, false)
         battler.eachOpposing do |oppBattler|
             oppBattler.pbLowerMultipleStatSteps(statDown,battler,item: item)
         end
-        next true
+        next false
     }
 )


### PR DESCRIPTION
Consume item before dropping the opponent's stats so it's not still there when *their* Black Herb triggers
Needs testing
Fix #345 