### PR TITLE
Allow avatars to heal during phase transitions

### DIFF
--- a/Plugins/Chasm Battle/Battle/PokeBattle_Misc.rb
+++ b/Plugins/Chasm Battle/Battle/PokeBattle_Misc.rb
@@ -166,7 +166,8 @@ class PokeBattle_Battle
             b.pbCancelMoves # Cancels multi-turn moves
 
             # Use each empowered status move
-            b.eachEmpoweredStatusMove do |move, index|               
+            b.phaseTransitioning = true
+            b.eachEmpoweredStatusMove do |move, index|
                 if showMessages
                   if usedEmpoweredMove
                     pbDisplaySlower(_INTL("What?! Even more energy rises up from inside {1}!!", b.pbThis(true)))
@@ -174,10 +175,11 @@ class PokeBattle_Battle
                     pbDisplaySlower(_INTL("A great energy rises up from inside {1}!", b.pbThis(true)))
                   end
                 end
-                
+
                 b.pbUseMove([:UseMove, index, move, -1, 0])
                 usedEmpoweredMove = true
             end
+            b.phaseTransitioning = false
             
             next unless usedEmpoweredMove
 

--- a/Plugins/Chasm Battle/Battler/Battler_ChangeSelf.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_ChangeSelf.rb
@@ -209,7 +209,7 @@ class PokeBattle_Battler
             amt = 1 if amt < 1 && @hp < @totalhp
 
             # Cap boss healing at the next health boundary
-            if boss?
+            if boss? && !@phaseTransitioning
                 if @hp <= avatarPhaseLowerHealthBound && @hp + amt > avatarPhaseLowerHealthBound
                     amt = avatarPhaseLowerHealthBound - @hp
                 end

--- a/Plugins/Chasm Battle/Battler/Battler_Initialize.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Initialize.rb
@@ -265,6 +265,7 @@ class PokeBattle_Battler
 
         # Boss stuff
         @avatarPhase           = 1
+        @phaseTransitioning    = false
         @empoweredTimer		   = 0
         @extraMovesPerTurn = 0
         @indicesTargetedRoundBeforeLast = []

--- a/Plugins/Chasm Battle/Battler/Battler_Properties.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Properties.rb
@@ -15,7 +15,7 @@ class PokeBattle_Battler
     attr_accessor :movesUsedThisTurn, :movesUsedLastTurn
 
     # Avatar stuff
-    attr_accessor  :boss, :avatarPhase
+    attr_accessor  :boss, :avatarPhase, :phaseTransitioning
     attr_accessor  :indicesTargetedThisRound, :indicesTargetedLastRound, :indicesTargetedRoundBeforeLast
     attr_accessor  :empoweredTimer, :dmgMult, :dmgResist
 


### PR DESCRIPTION
Previously, the cap meant to prevent phase stalling would also affect Primeval healing moves like Heal Order, making their effects negligible. 
Fix #99

Development notes:
This approach of setting a flag specifically for this purpose is slightly awkward. I considered other approaches, but they didn't work out. It would be elegant enough in theory to specifically check if the move causing the HP recovery is Primeval and ignore the cap if so, but that information is not readily accessible in the pbRecoverHP scope. Similarly, I thought about adding a parameter to pbRecoverHP to ignore the cap, which the Primeval moves would set to true, but this would require refactoring each Primeval healing move since they currently call super on their base healing moves, which shouldn't ignore the cap. This seems like the least intrusive solution without a major refactor.