### PR TITLE
Restrict JUGGLING ability to once per turn

### DIFF
--- a/PBS/abilities_new.txt
+++ b/PBS/abilities_new.txt
@@ -1217,7 +1217,7 @@ Flags = MoldBreaking
 #-------------------------------
 [JUGGLING]
 Name = Juggling
-Description = When this Pokémon consumes an item, it is passed to its ally. When its ally consumes an item, it is passed to this Pokémon.
+Description = The first time each turn this Pokémon consumes an item, it is passed to its ally, and vice versa.
 #-------------------------------
 [KARMA]
 Name = Karma

--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Other Triggers/OnItemActivatedAbilities.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Other Triggers/OnItemActivatedAbilities.rb
@@ -2,6 +2,7 @@
 # If multiple valid allies exist and the user is player-controlled, the player chooses.
 BattleHandlers::OnItemActivatedAbility.add(:JUGGLING,
     proc { |ability, user, item, battle|
+        next if user.hasEffect?(:JugglingThrown)
         valid_allies = []
         user.eachAlly { |b| valid_allies << b if b.canAddItem?(item) }
         next if valid_allies.empty?
@@ -17,6 +18,7 @@ BattleHandlers::OnItemActivatedAbility.add(:JUGGLING,
         else
             ally = valid_allies.sample
         end
+        user.applyEffect(:JugglingThrown)
         ally.giveItem(item)
         battle.pbDisplay(_INTL("{1} juggled its {2} to {3}!", user.pbThis, getItemName(item), ally.pbThis(true)))
         battle.pbHideAbilitySplash(user)
@@ -29,11 +31,13 @@ BattleHandlers::OnAllyItemActivatedAbility.add(:JUGGLING,
     proc { |ability, user, consumer, item, battle|
         # Skip if the consumer also has JUGGLING — already handled by OnItemActivatedAbility
         next if consumer.hasActiveAbility?(:JUGGLING)
+        next if user.hasEffect?(:JugglingCaught)
         next unless user.canAddItem?(item)
         # Prevent multiple Juggling users from each catching the same item.
         # The flag is reset at the call site before each activation's ally loop.
         next if battle.jugglingItemTaken
         battle.jugglingItemTaken = true
+        user.applyEffect(:JugglingCaught)
         battle.pbShowAbilitySplash(user, ability)
         user.giveItem(item)
         battle.pbDisplay(_INTL("{1} caught {2}'s {3}!", user.pbThis, consumer.pbThis(true), getItemName(item)))

--- a/Plugins/Chasm Battle/Effects/EffectDefinitions/BattlerEffects.rb
+++ b/Plugins/Chasm Battle/Effects/EffectDefinitions/BattlerEffects.rb
@@ -5,6 +5,20 @@ def aquaRingHealingFraction(battler)
 end
 
 GameData::BattleEffect.register_effect(:Battler, {
+    :id => :JugglingThrown,
+    :real_name => "Juggling Thrown",
+    :resets_battlers_eot => true,
+    :resets_battlers_sot => true,
+})
+
+GameData::BattleEffect.register_effect(:Battler, {
+    :id => :JugglingCaught,
+    :real_name => "Juggling Caught",
+    :resets_battlers_eot => true,
+    :resets_battlers_sot => true,
+})
+
+GameData::BattleEffect.register_effect(:Battler, {
     :id => :AquaRing,
     :real_name => "Aqua Ring",
     :baton_passed => true,


### PR DESCRIPTION
Avoid infinite loops by only allowing a JUGGLING user to throw and catch an item each once per turn. This prevents infinite loops like pinch berries while still allowing creative strategies for passing items back and forth.
Fix #380 