### PR TITLE
Add special handling for Emergency Exit

### DIFF
--- a/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
@@ -433,6 +433,12 @@ class PokeBattle_AI
             realDamage = target.hp
             damageScore = 250
             willFaint = true
+        elsif target.aboveHalfHealth? &&
+              target.hp - realDamage <= target.totalhp / 2 &&
+              (target.hasActiveAbilityAI?(:EMERGENCYEXIT) || target.hasActiveAbilityAI?(:WIMPOUT))
+            damageScore = 200 # A bit less valuable than a true faint
+            willFaint = true # Golisopod should treat getting outsped like a faint risk in this scenario, it won't get off an attack
+            echoln("\t[MOVE SCORING] #{target.pbThis(true)} has Emergency Exit/Wimp Out and will be forced out; treating as near-faint")
         else
             # Only care about KO thresholds
             if damagePercentage >= 50 || subDestroyed == true # Breaking a sub is as good as doing 50%

--- a/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Trainer.rb
@@ -424,6 +424,14 @@ class PokeBattle_AI
     # Add to a move's score based on how much damage it will deal (as a percentage
     # of the target's current HP)
     #=============================================================================
+    def moveWillTriggerEmergencyExit?(target, damage)
+        return false unless target.aboveHalfHealth?
+        return false unless target.hp - damage <= target.totalhp / 2
+        return false unless target.hasActiveAbilityAI?(:EMERGENCYEXIT) || target.hasActiveAbilityAI?(:WIMPOUT)
+        return false unless @battle.pbCanSwitch?(target.index) && @battle.pbCanChooseNonActive?(target.index)
+        return true
+    end
+
     def pbGetMoveScoreDamage(move, user, target, numTargets = 1, aiContext = nil)
         realDamage,damagePercentage,subDestroyed = getDamageAnalysisAI(move, user, target, numTargets, aiContext)
 
@@ -433,9 +441,7 @@ class PokeBattle_AI
             realDamage = target.hp
             damageScore = 250
             willFaint = true
-        elsif target.aboveHalfHealth? &&
-              target.hp - realDamage <= target.totalhp / 2 &&
-              (target.hasActiveAbilityAI?(:EMERGENCYEXIT) || target.hasActiveAbilityAI?(:WIMPOUT))
+        elsif moveWillTriggerEmergencyExit?(target, realDamage)
             damageScore = 200 # A bit less valuable than a true faint
             willFaint = true # Golisopod should treat getting outsped like a faint risk in this scenario, it won't get off an attack
             echoln("\t[MOVE SCORING] #{target.pbThis(true)} has Emergency Exit/Wimp Out and will be forced out; treating as near-faint")


### PR DESCRIPTION
Make AI think it will be fainted if EE would be triggered, so that Golisopod knows it won't get an attack off

Needs testing

Fix #369 