### PR TITLE
Show speaker labels for messages called from scripts

### DIFF
--- a/Plugins/Chasm Graphics and UI/Objects and windows/Messages.rb
+++ b/Plugins/Chasm Graphics and UI/Objects and windows/Messages.rb
@@ -626,6 +626,7 @@ def pbMessageDisplay(msgwindow, message, letterbyletter = true, commandProc = ni
     ########## Show text #############################
     msgwindow.text = text
     Graphics.frame_reset if Graphics.frame_rate > 40
+    showSpeaker
     iconFadeInCount = iconFadeInTime
     loop do
         if $SpeakerNameWindow

--- a/Plugins/Chasm PokEstate/PokEstateMain.rb
+++ b/Plugins/Chasm PokEstate/PokEstateMain.rb
@@ -395,8 +395,8 @@ class PokEstate
 		firstPage.graphic.character_name = caretakerSprite
 		firstPage.trigger = 0 # Action button
 		firstPage.list = []
-		push_text(firstPage.list,"Welcome back to the PokÉstate, young master.")
 		push_script(firstPage.list,sprintf("setSpeaker(CARETAKER)",))
+		push_text(firstPage.list,"Welcome back to the PokÉstate, young master.")
 		push_script(firstPage.list,sprintf("$PokEstate.careTakerInteraction",))
 		firstPage.list.push(RPG::EventCommand.new(0,0,[]))
 		


### PR DESCRIPTION
Previously was only working for messages called from RPG Maker events

Relevant to https://github.com/Pokemon-Tectonic-Team/Pokemon-Tectonic-Content/issues/315. Pending testing by @ShadowKirbae 