### PR TITLE
Add system for setting speaker in Ruby functions

### DIFF
--- a/Plugins/Chasm Graphics and UI/Objects and windows/Dialogue Labels/DialogueLabels.rb
+++ b/Plugins/Chasm Graphics and UI/Objects and windows/Dialogue Labels/DialogueLabels.rb
@@ -17,7 +17,7 @@ def setSpeakerRuby(speakerName,viewport = nil)
     end
     $SpeakerNameWindowRuby.text = _INTL(speakerName)
     $SpeakerNameWindowRuby.viewport = viewport
-    refreshSpeakerWindow
+    refreshSpeakerWindowRuby
 end
 
 def refreshSpeakerWindow
@@ -27,6 +27,15 @@ def refreshSpeakerWindow
     $SpeakerNameWindow.y = Graphics.height - $SpeakerNameWindow.height
     $SpeakerNameWindow.z = 99_999
     $SpeakerNameWindow.visible = false # Starts hidden
+end
+
+def refreshSpeakerWindowRuby
+    return unless $SpeakerNameWindowRuby
+    $SpeakerNameWindowRuby.resizeToFit($SpeakerNameWindowRuby.text,Graphics.width)
+    $SpeakerNameWindowRuby.width = 160 if $SpeakerNameWindowRuby.width <= 160
+    $SpeakerNameWindowRuby.y = Graphics.height - $SpeakerNameWindowRuby.height
+    $SpeakerNameWindowRuby.z = 99_999
+    $SpeakerNameWindowRuby.visible = false # Starts hidden
 end
 
 def setSpeakerTrainer(trainerClass,trainerName)

--- a/Plugins/Chasm Graphics and UI/Objects and windows/Dialogue Labels/DialogueLabels.rb
+++ b/Plugins/Chasm Graphics and UI/Objects and windows/Dialogue Labels/DialogueLabels.rb
@@ -8,6 +8,18 @@ def setSpeaker(speakerName,viewport = nil)
     refreshSpeakerWindow
 end
 
+# A separate version of setSpeaker that works in Ruby functions without affecting the behaviour in scripts
+# It is the calling function's responsibility to call removeSpeakerRuby before moving into a function that will display speakerless messages
+def setSpeakerRuby(speakerName,viewport = nil)
+    unless $SpeakerNameWindowRuby
+        $SpeakerNameWindowRuby = Window_AdvancedTextPokemon.new
+        $SpeakerNameWindowRuby.setSkin(MessageConfig.pbGetSpeechFrame)
+    end
+    $SpeakerNameWindowRuby.text = _INTL(speakerName)
+    $SpeakerNameWindowRuby.viewport = viewport
+    refreshSpeakerWindow
+end
+
 def refreshSpeakerWindow
     return unless $SpeakerNameWindow
     $SpeakerNameWindow.resizeToFit($SpeakerNameWindow.text,Graphics.width)
@@ -40,7 +52,17 @@ def showSpeaker
     $SpeakerNameWindow.visible = true
 end
 
+def showSpeakerRuby
+    return unless $SpeakerNameWindowRuby
+    $SpeakerNameWindowRuby.visible = true
+end
+
 def removeSpeaker
     $SpeakerNameWindow.dispose if $SpeakerNameWindow
     $SpeakerNameWindow = nil
+end
+
+def removeSpeakerRuby
+    $SpeakerNameWindowRuby.dispose if $SpeakerNameWindowRuby
+    $SpeakerNameWindowRuby = nil
 end

--- a/Plugins/Chasm Graphics and UI/Objects and windows/Messages.rb
+++ b/Plugins/Chasm Graphics and UI/Objects and windows/Messages.rb
@@ -626,6 +626,7 @@ def pbMessageDisplay(msgwindow, message, letterbyletter = true, commandProc = ni
     ########## Show text #############################
     msgwindow.text = text
     Graphics.frame_reset if Graphics.frame_rate > 40
+    showSpeakerRuby # will show speaker labels defined in ruby functions, but not when called from an RPG Maker event which assumes the speaker will be disposed
     iconFadeInCount = iconFadeInTime
     loop do
         if $SpeakerNameWindow

--- a/Plugins/Chasm PokEstate/PokEstateMain.rb
+++ b/Plugins/Chasm PokEstate/PokEstateMain.rb
@@ -276,18 +276,21 @@ class PokEstate
 		commands[commandReceiveUpdate = commands.length] = _INTL("Hear Story") if STORIES_FEATURE_AVAILABLE
 		commands[commandCancel = commands.length] = _INTL("Cancel")
 		
-		setSpeaker(CARETAKER)
+		setSpeakerRuby(CARETAKER)
 		command = pbMessage(_INTL("What would you like to do?"),commands,commandCancel+1)
 		
 		if commandLandscape > -1 && command == commandLandscape
+			removeSpeakerRuby
 			changeLandscape()
-        elsif commandCheckRewards > -1 && command == commandCheckRewards
+		elsif commandCheckRewards > -1 && command == commandCheckRewards
+            removeSpeakerRuby
             pbFadeOutIn do
                 collectionRewardsListScene = CollectionRewardsListScene.new
                 screen = CollectionRewardsListScreen.new(collectionRewardsListScene)
                 screen.pbStartScreen
             end
 		elsif commandReceiveUpdate > -1 && command == commandReceiveUpdate
+			# we don't remove speaker here because this dialogue is also the Caretaker's, I think
 			tryHearStory()
 		end
 	end


### PR DESCRIPTION
pbMessage doesn't call showSpeaker, unlike RPG Maker Show Text. This is actually intentional - when calling a utility function from a script, the speaker won't accidentally transfer. However, sometimes we do want to set a speaker for use with pbMessage. So there's a new dedicated function to do it. It requires manual cleanup before calling utility functions.

This is kinda janky, but better options would involve having to add removeSpeaker to a lot of events, or totally refactoring the system, neither of which are terribly practical right now. 