### PR TITLE
Reintroduce ability handler for Aromatic

### DIFF
--- a/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesKnockedBelowHalf.rb
+++ b/Plugins/Chasm Battle/Abilities/Ability Event Handlers/Move End/TargetAbilitiesKnockedBelowHalf.rb
@@ -96,6 +96,12 @@ BattleHandlers::TargetAbilityKnockedBelowHalf.add(:DREAMYHAZE,
     }
 )
 
+BattleHandlers::TargetAbilityKnockedBelowHalf.add(:AROMATIC,
+    proc { |ability, target, user, move, _switched, battle|
+        battle.forceUseMove(target, :AROMATHERAPY, ability: ability)
+    }
+)
+
 BattleHandlers::TargetAbilityKnockedBelowHalf.add(:SUDDENTURN,
     proc { |ability, target, user, move, _switched, battle|
         battle.forceUseMove(target, :RAPIDSPIN, ability: ability)


### PR DESCRIPTION
Aromatic's ability handler was cut from the game when removed from the Venusaur line, and not brought back when given to the Polteageist line. This fixes the issue by copying back the old code.

Fixes issue #435.