### PR TITLE
Teaching the AI two turn moves don't actually deal damage on turn 1.

### DIFF
--- a/Plugins/Chasm Battle/AI/AI_Move_Utilities.rb
+++ b/Plugins/Chasm Battle/AI/AI_Move_Utilities.rb
@@ -123,6 +123,13 @@ class PokeBattle_AI
     def pbTotalDamageAI(move, user, target, numTargets = 1, aiContext = nil)
         return 0, false if move.damageNegated?(user, target, true)
 
+		# TODO: don't score 0, figure out a better way to go about this,
+		# maybe halve the score of how much damage it would do on the
+		# damaging turn?
+        if move.is_a?(PokeBattle_TwoTurnMove)
+            return 0, false unless move.dealsDamageThisTurnAI?(user)
+        end
+
         # Get the move's type
         type = pbRoughType(move, user)
 

--- a/Plugins/Chasm Battle/Move Codes/ParentMoveCodes.rb
+++ b/Plugins/Chasm Battle/Move Codes/ParentMoveCodes.rb
@@ -666,6 +666,13 @@ class PokeBattle_TwoTurnMove < PokeBattle_Move
     def shouldHighlight?(user, _target)
         return skipChargingTurn?(user)
     end
+
+    def dealsDamageThisTurnAI?(user)
+        return true if user.effectActive?(:TwoTurnAttack)
+        return true if skipChargingTurn?(user)
+        return true if user.hasActiveItemAI?(:POWERHERB)
+        return false
+    end
 end
 
 #===============================================================================


### PR DESCRIPTION
#421 
Leaving this as a draft for now. The AI currently doesn't know charging moves don't deal damage on turn 1, which can lead to awkward scenarios where the AI sees kills with a charging move, only to go for it and then faint before actually getting the attack off.
This probably requires some testing afterwards. First tests looked promissing but gotta figure out a better way to actually score this, rather than just 0'ing the score.