### PR TITLE
Clamp menuLastChoice within proper bounds

### DIFF
--- a/Plugins/Chasm Graphics and UI/Objects and windows/TilingCardsMenu.rb
+++ b/Plugins/Chasm Graphics and UI/Objects and windows/TilingCardsMenu.rb
@@ -99,6 +99,10 @@ class TilingCardsMenu_Scene
 		$viewport4 = @viewport
 
 		@buttonSelectionIndex = defaultCursorPosition
+		buttonCount = @cardButtons.keys.length
+		if buttonCount > 0
+			@buttonSelectionIndex = @buttonSelectionIndex.clamp(0, buttonCount - 1)
+		end
 
 		drawButtons
 	end


### PR DESCRIPTION
May prevent crashes. If this is the error people are encountering, it's not clear why quicksaving first would prevent it, but the guard couldn't hurt.