### PR TITLE
Dragon Darts crash fix

### DIFF
--- a/Plugins/Chasm Battle/Move Codes/Move_Codes_Multihit.rb
+++ b/Plugins/Chasm Battle/Move Codes/Move_Codes_Multihit.rb
@@ -272,6 +272,7 @@ class PokeBattle_Move_HitTwoTimesTargetThenTargetAlly < PokeBattle_Move_HitTwoTi
             end
         end
         return [valid_targets[1]] if indexThisHit == 1 && valid_targets[1]
+        return [] if valid_targets.empty?
         return [valid_targets[0]]
     end
 end


### PR DESCRIPTION
Something to do with invalid targeting. I don't understand the exact circumstances myself, it was surfaced by automatic random battling for my AI benchmarking.