### PR TITLE
AI hide stat items

### DIFF
--- a/Plugins/Chasm Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
+++ b/Plugins/Chasm Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
@@ -292,6 +292,36 @@ class PokeBattle_Battle
         return ret
     end
 
+    # True if `battler`'s real speed orders it differently than `hiddenSpeed`
+    # would, against any co-bracket move-user this round (ally OR opponent). Used
+    # to decide whether a disguising speed item produced an observably unexpected
+    # turn order. Only battlers sharing this round's priority and sub-priority
+    # bracket are compared, since across brackets speed does not decide order;
+    # Tricksters Domain (reversed speed order) is respected.
+    def speedItemOrderAnomaly?(battler, realSpeed, hiddenSpeed)
+        return false if realSpeed == hiddenSpeed
+        return false if @priority.nil? || @priority.empty?
+        myEntry = @priority.find { |e| e && e[0] == battler }
+        return false if myEntry.nil?
+        myPriority, mySubPriority = myEntry[3], myEntry[2]
+        reversed = @priorityTrickstersDomain
+        @priority.each do |e|
+            next unless e
+            other = e[0]
+            next if other.nil? || other == battler || other.fainted?
+            # Only battlers actually taking a move action this round are ordered by speed
+            otherChoice = @choices[other.index][0]
+            next unless otherChoice == :UseMove || otherChoice == :Shift
+            # Different priority/sub-priority bracket: speed never decides their order
+            next unless e[3] == myPriority && e[2] == mySubPriority
+            otherSpeed = e[1]
+            realFaster   = reversed ? (realSpeed   < otherSpeed) : (realSpeed   > otherSpeed)
+            hiddenFaster = reversed ? (hiddenSpeed < otherSpeed) : (hiddenSpeed > otherSpeed)
+            return true if realFaster != hiddenFaster
+        end
+        return false
+    end
+
     # Returns a hash assigning each unfainted battler a number which explains in what order the battlers
     # are expected to move this turn, accounting for only speed and trickster's domain
     # Pokemon with speed ties are assigned the same number

--- a/Plugins/Chasm Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
+++ b/Plugins/Chasm Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
@@ -315,7 +315,7 @@ class PokeBattle_Battle
             # Different priority/sub-priority bracket: speed never decides their order
             next unless e[3] == myPriority && e[2] == mySubPriority
             otherSpeed = e[1]
-            realFaster   = reversed ? (realSpeed   < otherSpeed) : (realSpeed   > otherSpeed)
+            realFaster = reversed ? (realSpeed < otherSpeed) : (realSpeed > otherSpeed)
             hiddenFaster = reversed ? (hiddenSpeed < otherSpeed) : (hiddenSpeed > otherSpeed)
             return true if realFaster != hiddenFaster
         end

--- a/Plugins/Chasm Battle/Battler/Battler_StatStages.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_StatStages.rb
@@ -35,9 +35,9 @@ class PokeBattle_Battler
         return mult
     end
 
-    def statAfterStep(stat, step = nil)
+    def statAfterStep(stat, step = nil, aiCheck = false)
         step = @steps[stat] if step.nil?
-        return (getPlainStat(stat) * statMultiplierAtStep(step)).floor
+        return (getPlainStat(stat, aiCheck) * statMultiplierAtStep(step)).floor
     end
 
     def finalStats

--- a/Plugins/Chasm Battle/Battler/Battler_Stats.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Stats.rb
@@ -1,16 +1,16 @@
 class PokeBattle_Battler
-    def getPlainStat(stat)
+    def getPlainStat(stat, aiCheck = false)
         case stat
         when :ATTACK
-            return attack
+            return attack(aiCheck)
         when :DEFENSE
-            return defense
+            return defense(aiCheck)
         when :SPECIAL_ATTACK
-            return spatk
+            return spatk(aiCheck)
         when :SPECIAL_DEFENSE
-            return spdef
+            return spdef(aiCheck)
         when :SPEED
-            return speed
+            return speed(aiCheck)
         end
         return -1
     end
@@ -46,51 +46,51 @@ class PokeBattle_Battler
         return false
     end
 
-    def attack
+    def attack(aiCheck = false)
         if puzzleRoom? && oddRoom?
-            return base_special_defense
+            return base_special_defense(aiCheck)
         elsif puzzleRoom? && !oddRoom?
-            return base_special_attack
+            return base_special_attack(aiCheck)
         elsif oddRoom? && !puzzleRoom?
-            return base_defense
+            return base_defense(aiCheck)
         else
-            return base_attack
+            return base_attack(aiCheck)
         end
     end
 
-    def defense
+    def defense(aiCheck = false)
         if wonderRoom? && oddRoom?
-            return base_special_attack
+            return base_special_attack(aiCheck)
         elsif wonderRoom? && !oddRoom?
-            return base_special_defense
+            return base_special_defense(aiCheck)
         elsif oddRoom? && !wonderRoom?
-            return base_attack
+            return base_attack(aiCheck)
         else
-            return base_defense
+            return base_defense(aiCheck)
         end
     end
 
-    def spatk
+    def spatk(aiCheck = false)
         if puzzleRoom? && oddRoom?
-            return base_defense
+            return base_defense(aiCheck)
         elsif puzzleRoom? && !oddRoom?
-            return base_attack
+            return base_attack(aiCheck)
         elsif oddRoom? && !puzzleRoom?
-            return base_special_defense
+            return base_special_defense(aiCheck)
         else
-            return base_special_attack
+            return base_special_attack(aiCheck)
         end
     end
 
-    def spdef
+    def spdef(aiCheck = false)
         if wonderRoom? && oddRoom?
-            return base_attack
+            return base_attack(aiCheck)
         elsif wonderRoom? && !oddRoom?
-            return base_defense
+            return base_defense(aiCheck)
         elsif oddRoom? && !wonderRoom?
-            return base_special_attack
+            return base_special_attack(aiCheck)
         else
-            return base_special_defense
+            return base_special_defense(aiCheck)
         end
     end
 
@@ -98,7 +98,7 @@ class PokeBattle_Battler
 
     DEFENSIVE_LOCK_STAT = 95
 
-    def speed
+    def speed(aiCheck = false)
         return base_speed
     end
 
@@ -107,18 +107,19 @@ class PokeBattle_Battler
         return calcStatGlobal(base, @level, @pokemon.ev[stat], stylish: hasActiveAbility?(:STYLISH), accumulation: hasActiveAbility?(:ACCUMULATION))
     end
 
-    def base_attack
+    def base_attack(aiCheck = false)
         return @effects[:BaseAttack] if effectActive?(:BaseAttack)
         attack_bonus = tribalBonusForStat(:ATTACK)
         attack_bonus += allStatBonus
-        if hasActiveItem?(%i[POWERLOCK POWERKEY])
+        if hasActiveItem?(%i[POWERLOCK POWERKEY]) && !aiHidesStatItem?(:POWERLOCK, aiCheck)
+            revealHiddenStatItems(:POWERLOCK) unless aiCheck
             return recalcStat(:ATTACK, OFFENSIVE_LOCK_STAT) + attack_bonus
         else
             return @attack + attack_bonus
         end
     end
 
-    def base_defense
+    def base_defense(aiCheck = false)
         return @effects[:BaseDefense] if effectActive?(:BaseDefense)
         defense_bonus = tribalBonusForStat(:DEFENSE)
         defense_bonus += allStatBonus
@@ -131,18 +132,19 @@ class PokeBattle_Battler
         end
     end
 
-    def base_special_attack
+    def base_special_attack(aiCheck = false)
         return @effects[:BaseSpecialAttack] if effectActive?(:BaseSpecialAttack)
         spatk_bonus = tribalBonusForStat(:SPECIAL_ATTACK)
         spatk_bonus += allStatBonus
-        if hasActiveItem?(%i[ENERGYLOCK ENERGYKEY])
+        if hasActiveItem?(%i[ENERGYLOCK ENERGYKEY]) && !aiHidesStatItem?(:ENERGYLOCK, aiCheck)
+            revealHiddenStatItems(:ENERGYLOCK) unless aiCheck
             return recalcStat(:SPECIAL_ATTACK, OFFENSIVE_LOCK_STAT) + spatk_bonus
         else
             return @spatk + spatk_bonus
         end
     end
 
-    def base_special_defense
+    def base_special_defense(aiCheck = false)
         return @effects[:BaseSpecialDefense] if effectActive?(:BaseSpecialDefense)
         spdef_bonus = tribalBonusForStat(:SPECIAL_DEFENSE)
         spdef_bonus += allStatBonus
@@ -167,9 +169,54 @@ class PokeBattle_Battler
     #=============================================================================
     AI_CHEATS_FOR_STAT_ABILITIES = true
 
+    # When false, the AI estimates an opposing player-owned battler's stats as if
+    # it were not holding certain disguising stat items, until the item reveals
+    # itself through real (non-AI) use. Set true to let the AI always see them.
+    AI_CHEATS_FOR_STAT_ITEMS = false
+
+    # Held items whose stat contribution is hidden from the AI's stat/damage
+    # estimates until revealed. Covers the multiplier items applied in the
+    # pbAttack/pbSpAtk/pbDefense/pbSpDef/pbSpeed item loops, plus the offensive
+    # base-stat "lock" items applied in base_attack / base_special_attack.
+    AI_HIDDEN_STAT_ITEMS = %i[
+        CHOICEBAND CHOICESPECS CHOICESCARF
+        SEVENLEAGUEBOOTS
+        ASSAULTVEST STRIKEVEST
+        POWERLOCK ENERGYLOCK
+    ]
+
+    # True when the AI should not yet see this held item's stat contribution: it
+    # is a hidden stat item on a player-owned battler that the AI has not learned,
+    # and this is an AI estimate (aiCheck) with the item cheat disabled. Accepts a
+    # single item id or an array (any matching held item triggers hiding).
+    def aiHidesStatItem?(item, aiCheck)
+        return false unless aiCheck
+        return false if AI_CHEATS_FOR_STAT_ITEMS
+        return false unless pbOwnedByPlayer?
+        return Array(item).any? do |singleItem|
+            AI_HIDDEN_STAT_ITEMS.include?(singleItem) &&
+                hasActiveItem?(singleItem) &&
+                !aiKnowsItem?(singleItem)
+        end
+    end
+
+    # Reveal any of the given hidden stat items this player-owned battler actually
+    # holds. Called on real (non-AI) stat application so the AI learns the item
+    # once it has demonstrably affected a real action (attacking, being hit, or
+    # turn-order resolution, depending on the item).
+    def revealHiddenStatItems(*items)
+        return unless pbOwnedByPlayer?
+        items.flatten.each do |singleItem|
+            next unless AI_HIDDEN_STAT_ITEMS.include?(singleItem)
+            next unless hasActiveItem?(singleItem)
+            next if aiKnowsItem?(singleItem)
+            aiLearnsItem(singleItem)
+        end
+    end
+
     def pbAttack(aiCheck = false, step = nil)
         return 1 if fainted? && !dummy?
-        attack = statAfterStep(:ATTACK, step)
+        attack = statAfterStep(:ATTACK, step, aiCheck)
         attackMult = 1.0
 
         eachActiveAbility do |ability|
@@ -184,7 +231,9 @@ class PokeBattle_Battler
         end
 
         eachActiveItem do |item|
+            next if aiHidesStatItem?(item, aiCheck)
             attackMult = BattleHandlers.triggerAttackCalcUserItem(item, self, battle, attackMult)
+            revealHiddenStatItems(item) unless aiCheck
         end
 
         # Dragon Ride
@@ -196,7 +245,7 @@ class PokeBattle_Battler
 
     def pbSpAtk(aiCheck = false, step = nil)
         return 1 if fainted? && !dummy?
-        special_attack = statAfterStep(:SPECIAL_ATTACK, step)
+        special_attack = statAfterStep(:SPECIAL_ATTACK, step, aiCheck)
         spAtkMult = 1.0
 
         eachActiveAbility do |ability|
@@ -211,7 +260,9 @@ class PokeBattle_Battler
         end
 
         eachActiveItem do |item|
+            next if aiHidesStatItem?(item, aiCheck)
             spAtkMult = BattleHandlers.triggerSpecialAttackCalcUserItem(item, self, battle, spAtkMult)
+            revealHiddenStatItems(item) unless aiCheck
         end
 
         # Calculation
@@ -220,7 +271,7 @@ class PokeBattle_Battler
 
     def pbDefense(aiCheck = false, step = nil)
         return 1 if fainted? && !dummy?
-        defense = statAfterStep(:DEFENSE, step)
+        defense = statAfterStep(:DEFENSE, step, aiCheck)
         defenseMult = 1.0
 
         eachActiveAbility do |ability|
@@ -235,9 +286,11 @@ class PokeBattle_Battler
         end
 
         eachActiveItem do |item|
+            next if aiHidesStatItem?(item, aiCheck)
             defenseMult = BattleHandlers.triggerDefenseCalcUserItem(item, self, battle, defenseMult)
+            revealHiddenStatItems(item) unless aiCheck
         end
-        
+
         defenseMult *= 1.3 if hasTribeBonus?(:SCRAPPER)
         defenseMult *= 1.5 if pbOwnSide.effectActive?(:AutumnHarvests)
 
@@ -255,7 +308,7 @@ class PokeBattle_Battler
 
     def pbSpDef(aiCheck = false, step = nil)
         return 1 if fainted? && !dummy?
-        special_defense = statAfterStep(:SPECIAL_DEFENSE, step)
+        special_defense = statAfterStep(:SPECIAL_DEFENSE, step, aiCheck)
         spDefMult = 1.0
 
         eachActiveAbility do |ability|
@@ -269,9 +322,11 @@ class PokeBattle_Battler
         end
 
         eachActiveItem do |item|
+            next if aiHidesStatItem?(item, aiCheck)
             spDefMult = BattleHandlers.triggerSpecialDefenseCalcUserItem(item, self, battle, spDefMult)
+            revealHiddenStatItems(item) unless aiCheck
         end
-        
+
         spDefMult *= 1.3 if hasTribeBonus?(:RADIANT)
         spDefMult *= 1.5 if pbOwnSide.effectActive?(:SpringPlantings)
 
@@ -289,7 +344,7 @@ class PokeBattle_Battler
 
     def pbSpeed(aiCheck = false, step = nil, afterSwitching: false, move: nil)
         return 1 if fainted? && !dummy?
-        speed = statAfterStep(:SPEED, step)
+        speed = statAfterStep(:SPEED, step, aiCheck)
         speedMult = 1.0
 
         eachActiveAbility do |ability|
@@ -299,7 +354,9 @@ class PokeBattle_Battler
 
         # Item effects that alter calculated Speed
         eachActiveItem do |item|
+            next if aiHidesStatItem?(item, aiCheck)
             speedMult = BattleHandlers.triggerSpeedCalcItem(item, self, speedMult)
+            revealHiddenStatItems(item) unless aiCheck
         end
         
         # Other effects

--- a/Plugins/Chasm Battle/Battler/Battler_Stats.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Stats.rb
@@ -112,7 +112,6 @@ class PokeBattle_Battler
         attack_bonus = tribalBonusForStat(:ATTACK)
         attack_bonus += allStatBonus
         if hasActiveItem?(%i[POWERLOCK POWERKEY]) && !aiHidesStatItem?(:POWERLOCK, aiCheck)
-            revealHiddenStatItems(:POWERLOCK) unless aiCheck
             return recalcStat(:ATTACK, OFFENSIVE_LOCK_STAT) + attack_bonus
         else
             return @attack + attack_bonus
@@ -137,7 +136,6 @@ class PokeBattle_Battler
         spatk_bonus = tribalBonusForStat(:SPECIAL_ATTACK)
         spatk_bonus += allStatBonus
         if hasActiveItem?(%i[ENERGYLOCK ENERGYKEY]) && !aiHidesStatItem?(:ENERGYLOCK, aiCheck)
-            revealHiddenStatItems(:ENERGYLOCK) unless aiCheck
             return recalcStat(:SPECIAL_ATTACK, OFFENSIVE_LOCK_STAT) + spatk_bonus
         else
             return @spatk + spatk_bonus
@@ -175,15 +173,17 @@ class PokeBattle_Battler
     AI_CHEATS_FOR_STAT_ITEMS = false
 
     # Held items whose stat contribution is hidden from the AI's stat/damage
-    # estimates until revealed. Covers the multiplier items applied in the
-    # pbAttack/pbSpAtk/pbDefense/pbSpDef/pbSpeed item loops, plus the offensive
-    # base-stat "lock" items applied in base_attack / base_special_attack.
-    AI_HIDDEN_STAT_ITEMS = %i[
-        CHOICEBAND CHOICESPECS CHOICESCARF
-        SEVENLEAGUEBOOTS
-        ASSAULTVEST STRIKEVEST
-        POWERLOCK ENERGYLOCK
-    ]
+    # estimates until revealed. Split by how the item becomes evident in battle,
+    # which drives WHEN each is revealed (see revealActedHiddenStatItems /
+    # revealHitHiddenStatItems and their call sites). The reveal is event-driven,
+    # never triggered by a stat read.
+    #   offensive -> revealed when the holder takes its action (inflated damage)
+    #   speed     -> revealed when the holder takes its action (turn order seen)
+    #   defensive -> revealed when the holder is hit by a real damaging move
+    AI_HIDDEN_OFFENSIVE_ITEMS = %i[CHOICEBAND CHOICESPECS POWERLOCK ENERGYLOCK]
+    AI_HIDDEN_SPEED_ITEMS     = %i[CHOICESCARF SEVENLEAGUEBOOTS]
+    AI_HIDDEN_DEFENSIVE_ITEMS = %i[ASSAULTVEST STRIKEVEST]
+    AI_HIDDEN_STAT_ITEMS = (AI_HIDDEN_OFFENSIVE_ITEMS + AI_HIDDEN_SPEED_ITEMS + AI_HIDDEN_DEFENSIVE_ITEMS).freeze
 
     # True when the AI should not yet see this held item's stat contribution: it
     # is a hidden stat item on a player-owned battler that the AI has not learned,
@@ -201,9 +201,10 @@ class PokeBattle_Battler
     end
 
     # Reveal any of the given hidden stat items this player-owned battler actually
-    # holds. Called on real (non-AI) stat application so the AI learns the item
-    # once it has demonstrably affected a real action (attacking, being hit, or
-    # turn-order resolution, depending on the item).
+    # holds. Reveal is driven by observable battle EVENTS (the call sites below),
+    # never by a stat-calc method -- a stat read must never reveal an item, or
+    # routine real stat computations (turn-order priority, finalStats inside move
+    # effects, etc.) would mark items known before the AI ever estimates.
     def revealHiddenStatItems(*items)
         return unless pbOwnedByPlayer?
         items.flatten.each do |singleItem|
@@ -212,6 +213,18 @@ class PokeBattle_Battler
             next if aiKnowsItem?(singleItem)
             aiLearnsItem(singleItem)
         end
+    end
+
+    # Call when this battler takes its action (uses a move): its offensive and
+    # speed disguising items become evident (inflated damage / observed turn order).
+    def revealActedHiddenStatItems
+        revealHiddenStatItems(*AI_HIDDEN_OFFENSIVE_ITEMS, *AI_HIDDEN_SPEED_ITEMS)
+    end
+
+    # Call when this battler is hit by a real damaging move: its defensive
+    # disguising items become evident (the attacker's damage came up short).
+    def revealHitHiddenStatItems
+        revealHiddenStatItems(*AI_HIDDEN_DEFENSIVE_ITEMS)
     end
 
     def pbAttack(aiCheck = false, step = nil)
@@ -233,7 +246,6 @@ class PokeBattle_Battler
         eachActiveItem do |item|
             next if aiHidesStatItem?(item, aiCheck)
             attackMult = BattleHandlers.triggerAttackCalcUserItem(item, self, battle, attackMult)
-            revealHiddenStatItems(item) unless aiCheck
         end
 
         # Dragon Ride
@@ -262,7 +274,6 @@ class PokeBattle_Battler
         eachActiveItem do |item|
             next if aiHidesStatItem?(item, aiCheck)
             spAtkMult = BattleHandlers.triggerSpecialAttackCalcUserItem(item, self, battle, spAtkMult)
-            revealHiddenStatItems(item) unless aiCheck
         end
 
         # Calculation
@@ -288,7 +299,6 @@ class PokeBattle_Battler
         eachActiveItem do |item|
             next if aiHidesStatItem?(item, aiCheck)
             defenseMult = BattleHandlers.triggerDefenseCalcUserItem(item, self, battle, defenseMult)
-            revealHiddenStatItems(item) unless aiCheck
         end
 
         defenseMult *= 1.3 if hasTribeBonus?(:SCRAPPER)
@@ -324,7 +334,6 @@ class PokeBattle_Battler
         eachActiveItem do |item|
             next if aiHidesStatItem?(item, aiCheck)
             spDefMult = BattleHandlers.triggerSpecialDefenseCalcUserItem(item, self, battle, spDefMult)
-            revealHiddenStatItems(item) unless aiCheck
         end
 
         spDefMult *= 1.3 if hasTribeBonus?(:RADIANT)
@@ -356,7 +365,6 @@ class PokeBattle_Battler
         eachActiveItem do |item|
             next if aiHidesStatItem?(item, aiCheck)
             speedMult = BattleHandlers.triggerSpeedCalcItem(item, self, speedMult)
-            revealHiddenStatItems(item) unless aiCheck
         end
         
         # Other effects

--- a/Plugins/Chasm Battle/Battler/Battler_Stats.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Stats.rb
@@ -235,8 +235,9 @@ class PokeBattle_Battler
     end
 
     # Call when this battler takes its action: reveal a disguising speed item only
-    # if it produced an unexpected turn order (the item raised this battler past an
-    # opponent that its no-item, AI-estimated speed would not have outsped).
+    # if it produced an unexpected turn order (the item raised this battler past
+    # another battler -- ally or opponent -- that its no-item, AI-estimated speed
+    # would not have outsped). See @battle.speedItemOrderAnomaly? for the check.
     def revealSpeedHiddenStatItemsIfAnomalous
         return unless pbOwnedByPlayer?
         return if AI_CHEATS_FOR_STAT_ITEMS

--- a/Plugins/Chasm Battle/Battler/Battler_Stats.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Stats.rb
@@ -181,7 +181,8 @@ class PokeBattle_Battler
     #   physical-def -> holder takes damage from a PHYSICAL move
     #   special-def  -> holder takes damage from a SPECIAL move
     #   speed        -> holder moves in an unexpected turn order (item flipped it
-    #                   past an opponent its no-item speed would not outspeed)
+    #                   past another battler -- ally or opponent -- in the same
+    #                   priority bracket that its no-item speed would not outspeed)
     AI_HIDDEN_PHYSICAL_ATK_ITEMS = %i[CHOICEBAND POWERLOCK]
     AI_HIDDEN_SPECIAL_ATK_ITEMS  = %i[CHOICESPECS ENERGYLOCK]
     AI_HIDDEN_PHYSICAL_DEF_ITEMS = %i[STRIKEVEST]
@@ -247,19 +248,13 @@ class PokeBattle_Battler
         end
     end
 
+    # Anomaly is judged against this round's realized priority order, so it covers
+    # both opponents and this battler's own ally, and respects priority brackets
+    # and Tricksters Domain.
     def speedItemCausedOrderAnomaly?
         realSpeed = pbSpeed          # true speed, hidden item applied
         hiddenSpeed = pbSpeed(true)  # speed as the AI estimates it (item hidden)
-        return false if realSpeed <= hiddenSpeed
-        anomalous = false
-        eachOpposing do |b|
-            next if b.fainted?
-            bSpeed = b.pbSpeed
-            # The item flips the matchup vs b: without it b is at least as fast;
-            # with it this battler is faster.
-            anomalous = true if bSpeed >= hiddenSpeed && bSpeed < realSpeed
-        end
-        return anomalous
+        return @battle.speedItemOrderAnomaly?(self, realSpeed, hiddenSpeed)
     end
 
     def pbAttack(aiCheck = false, step = nil)

--- a/Plugins/Chasm Battle/Battler/Battler_Stats.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_Stats.rb
@@ -173,17 +173,23 @@ class PokeBattle_Battler
     AI_CHEATS_FOR_STAT_ITEMS = false
 
     # Held items whose stat contribution is hidden from the AI's stat/damage
-    # estimates until revealed. Split by how the item becomes evident in battle,
-    # which drives WHEN each is revealed (see revealActedHiddenStatItems /
-    # revealHitHiddenStatItems and their call sites). The reveal is event-driven,
-    # never triggered by a stat read.
-    #   offensive -> revealed when the holder takes its action (inflated damage)
-    #   speed     -> revealed when the holder takes its action (turn order seen)
-    #   defensive -> revealed when the holder is hit by a real damaging move
-    AI_HIDDEN_OFFENSIVE_ITEMS = %i[CHOICEBAND CHOICESPECS POWERLOCK ENERGYLOCK]
-    AI_HIDDEN_SPEED_ITEMS     = %i[CHOICESCARF SEVENLEAGUEBOOTS]
-    AI_HIDDEN_DEFENSIVE_ITEMS = %i[ASSAULTVEST STRIKEVEST]
-    AI_HIDDEN_STAT_ITEMS = (AI_HIDDEN_OFFENSIVE_ITEMS + AI_HIDDEN_SPEED_ITEMS + AI_HIDDEN_DEFENSIVE_ITEMS).freeze
+    # estimates until revealed. Reveal is event-driven (never triggered by a stat
+    # read) and category-specific, so an item only reveals on evidence that could
+    # actually expose it:
+    #   physical-atk -> holder deals damage with a PHYSICAL move
+    #   special-atk  -> holder deals damage with a SPECIAL move
+    #   physical-def -> holder takes damage from a PHYSICAL move
+    #   special-def  -> holder takes damage from a SPECIAL move
+    #   speed        -> holder moves in an unexpected turn order (item flipped it
+    #                   past an opponent its no-item speed would not outspeed)
+    AI_HIDDEN_PHYSICAL_ATK_ITEMS = %i[CHOICEBAND POWERLOCK]
+    AI_HIDDEN_SPECIAL_ATK_ITEMS  = %i[CHOICESPECS ENERGYLOCK]
+    AI_HIDDEN_PHYSICAL_DEF_ITEMS = %i[STRIKEVEST]
+    AI_HIDDEN_SPECIAL_DEF_ITEMS  = %i[ASSAULTVEST]
+    AI_HIDDEN_SPEED_ITEMS        = %i[CHOICESCARF SEVENLEAGUEBOOTS]
+    AI_HIDDEN_STAT_ITEMS = (AI_HIDDEN_PHYSICAL_ATK_ITEMS + AI_HIDDEN_SPECIAL_ATK_ITEMS +
+                            AI_HIDDEN_PHYSICAL_DEF_ITEMS + AI_HIDDEN_SPECIAL_DEF_ITEMS +
+                            AI_HIDDEN_SPEED_ITEMS).freeze
 
     # True when the AI should not yet see this held item's stat contribution: it
     # is a hidden stat item on a player-owned battler that the AI has not learned,
@@ -215,16 +221,45 @@ class PokeBattle_Battler
         end
     end
 
-    # Call when this battler takes its action (uses a move): its offensive and
-    # speed disguising items become evident (inflated damage / observed turn order).
-    def revealActedHiddenStatItems
-        revealHiddenStatItems(*AI_HIDDEN_OFFENSIVE_ITEMS, *AI_HIDDEN_SPEED_ITEMS)
+    # Call when this battler DEALS damage with a damaging move: its disguising
+    # offensive item for that move's category becomes evident (inflated damage).
+    def revealDealtDamageHiddenStatItems(physical)
+        revealHiddenStatItems(*(physical ? AI_HIDDEN_PHYSICAL_ATK_ITEMS : AI_HIDDEN_SPECIAL_ATK_ITEMS))
     end
 
-    # Call when this battler is hit by a real damaging move: its defensive
-    # disguising items become evident (the attacker's damage came up short).
-    def revealHitHiddenStatItems
-        revealHiddenStatItems(*AI_HIDDEN_DEFENSIVE_ITEMS)
+    # Call when this battler TAKES damage from a damaging move: its disguising
+    # defensive item for that move's category becomes evident (damage came short).
+    def revealTookDamageHiddenStatItems(physical)
+        revealHiddenStatItems(*(physical ? AI_HIDDEN_PHYSICAL_DEF_ITEMS : AI_HIDDEN_SPECIAL_DEF_ITEMS))
+    end
+
+    # Call when this battler takes its action: reveal a disguising speed item only
+    # if it produced an unexpected turn order (the item raised this battler past an
+    # opponent that its no-item, AI-estimated speed would not have outsped).
+    def revealSpeedHiddenStatItemsIfAnomalous
+        return unless pbOwnedByPlayer?
+        return if AI_CHEATS_FOR_STAT_ITEMS
+        AI_HIDDEN_SPEED_ITEMS.each do |item|
+            next unless hasActiveItem?(item)
+            next if aiKnowsItem?(item)
+            next unless speedItemCausedOrderAnomaly?
+            aiLearnsItem(item)
+        end
+    end
+
+    def speedItemCausedOrderAnomaly?
+        realSpeed = pbSpeed          # true speed, hidden item applied
+        hiddenSpeed = pbSpeed(true)  # speed as the AI estimates it (item hidden)
+        return false if realSpeed <= hiddenSpeed
+        anomalous = false
+        eachOpposing do |b|
+            next if b.fainted?
+            bSpeed = b.pbSpeed
+            # The item flips the matchup vs b: without it b is at least as fast;
+            # with it this battler is faster.
+            anomalous = true if bSpeed >= hiddenSpeed && bSpeed < realSpeed
+        end
+        return anomalous
     end
 
     def pbAttack(aiCheck = false, step = nil)

--- a/Plugins/Chasm Battle/Battler/Battler_UseMove.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_UseMove.rb
@@ -289,6 +289,7 @@ class PokeBattle_Battler
 
         # Record move as having been used
         aiSeesMove(move) if pbOwnedByPlayer? && !boss? # Enemy trainers now know of this move's existence
+        revealActedHiddenStatItems if pbOwnedByPlayer? && !boss? # Acting reveals disguising offensive/speed items
         aiLearnsAbility(:ILLUSION) if hasActiveAbility?(:ILLUSION) && effectActive?(:Illusion)
         aiLearnsAbility(:INCOGNITO) if hasActiveAbility?(:INCOGNITO) && effectActive?(:Illusion)
         increaseMoveUsageCount(move.id)

--- a/Plugins/Chasm Battle/Battler/Battler_UseMove.rb
+++ b/Plugins/Chasm Battle/Battler/Battler_UseMove.rb
@@ -289,7 +289,7 @@ class PokeBattle_Battler
 
         # Record move as having been used
         aiSeesMove(move) if pbOwnedByPlayer? && !boss? # Enemy trainers now know of this move's existence
-        revealActedHiddenStatItems if pbOwnedByPlayer? && !boss? # Acting reveals disguising offensive/speed items
+        revealSpeedHiddenStatItemsIfAnomalous if pbOwnedByPlayer? && !boss? # Reveal a speed item only if it caused an unexpected turn order
         aiLearnsAbility(:ILLUSION) if hasActiveAbility?(:ILLUSION) && effectActive?(:Illusion)
         aiLearnsAbility(:INCOGNITO) if hasActiveAbility?(:INCOGNITO) && effectActive?(:Illusion)
         increaseMoveUsageCount(move.id)

--- a/Plugins/Chasm Battle/Move/Move_Usage_DamageCalc.rb
+++ b/Plugins/Chasm Battle/Move/Move_Usage_DamageCalc.rb
@@ -37,9 +37,14 @@ class PokeBattle_Move
         # Get the relevant attacking and defending stat values (after steps)
         attack, defense = damageCalcStats(user,target,aiCheck)
 
-        # On a real (non-AI) hit, the target's disguising defensive items become
-        # evident to the AI: incoming damage came up short of the no-item estimate.
-        target.revealHitHiddenStatItems unless aiCheck
+        # On a real (non-AI) damaging hit, disguising items matching this move's
+        # category become evident: the user's offensive item (inflated damage) and
+        # the target's defensive item (damage came up short of the no-item estimate).
+        unless aiCheck
+            physical = physicalMove?
+            user.revealDealtDamageHiddenStatItems(physical)
+            target.revealTookDamageHiddenStatItems(physical)
+        end
 
         # Calculate all multiplier effects
         multipliers = initializeMultipliers

--- a/Plugins/Chasm Battle/Move/Move_Usage_DamageCalc.rb
+++ b/Plugins/Chasm Battle/Move/Move_Usage_DamageCalc.rb
@@ -37,6 +37,10 @@ class PokeBattle_Move
         # Get the relevant attacking and defending stat values (after steps)
         attack, defense = damageCalcStats(user,target,aiCheck)
 
+        # On a real (non-AI) hit, the target's disguising defensive items become
+        # evident to the AI: incoming damage came up short of the no-item estimate.
+        target.revealHitHiddenStatItems unless aiCheck
+
         # Calculate all multiplier effects
         multipliers = initializeMultipliers
         pbCalcDamageMultipliers(user,target,numTargets,type,baseDmg,multipliers,aiCheck,aiContext)


### PR DESCRIPTION
resolves #506 

AI sees stats not affected by the listed items by default now, then becomes aware of them when they come up (Band/Power Lock on using a physical move, Specs/Energy Lock on using a special move, Scarf/7league on acting at an unexpected turn order, and Vests when taking a physical/special move respectively)