### PR TITLE
Exp ez dispenser fix

### DIFF
--- a/Plugins/Chasm Battle/Battle/Battle_ExpAndMoveLearning.rb
+++ b/Plugins/Chasm Battle/Battle/Battle_ExpAndMoveLearning.rb
@@ -156,7 +156,7 @@ class PokeBattle_Battle
         end
         expFinal = expRaw.clamp(0, growth_rate.minimum_exp_for_level(level_cap))
         expGained = expFinal - pkmn.exp
-        expLeftovers -= pkmn.exp
+        expLeftovers -= expFinal
         expLeftovers = (expLeftovers * EXP_JAR_BASE_EFFICIENCY).floor
         @expStored += expLeftovers if expLeftovers > 0
         curLevel = pkmn.level

--- a/Plugins/Chasm Battle/Battle/Battle_ExpAndMoveLearning.rb
+++ b/Plugins/Chasm Battle/Battle/Battle_ExpAndMoveLearning.rb
@@ -87,11 +87,6 @@ class PokeBattle_Battle
     def pbGainExpOne(idxParty, defeatedBattler, numPartic, expShare, expAll, hasExpJAR, showMessages = true)
         pkmn = pbParty(0)[idxParty] # The Pokémon gaining exp from defeatedBattler
         growth_rate = pkmn.growth_rate
-        # Don't bother calculating if gainer is already at max Exp
-        if pkmn.exp >= growth_rate.maximum_exp
-            pkmn.calc_stats
-            return
-        end
         isPartic    = defeatedBattler.participants.include?(idxParty)
         hasExpShare = expShare.include?(idxParty)
         level = defeatedBattler.level
@@ -150,16 +145,16 @@ class PokeBattle_Battle
             return
         end
         # Make sure Exp doesn't exceed the maximum
-        level_cap = LEVEL_CAPS_USED ? getLevelCap : growth_rate.max_level
-        expFinal = growth_rate.add_exp(pkmn.exp, exp)
-        expLeftovers = expFinal.clamp(0, growth_rate.minimum_exp_for_level(level_cap))
+        level_cap = LEVEL_CAPS_USED ? getLevelCap : GrowthRate.max_level
+        expRaw = pkmn.exp + exp
+        expFinal = expRaw.clamp(0, growth_rate.minimum_exp_for_level(level_cap))
         # Calculates if there is excess exp and if it can be stored
-        if (expFinal > expLeftovers) && hasExpJAR
-            expLeftovers = expFinal.clamp(0, growth_rate.minimum_exp_for_level(level_cap + 1))
+        if (expRaw > expFinal) && hasExpJAR
+            expLeftovers = expRaw
         else
             expLeftovers = 0
         end
-        expFinal = expFinal.clamp(0, growth_rate.minimum_exp_for_level(level_cap))
+        expFinal = expRaw.clamp(0, growth_rate.minimum_exp_for_level(level_cap))
         expGained = expFinal - pkmn.exp
         expLeftovers -= pkmn.exp
         expLeftovers = (expLeftovers * EXP_JAR_BASE_EFFICIENCY).floor


### PR DESCRIPTION
commit 1 resolves #481 

commit 2 resolves #515 

side effect: previously, an individual mon's XP portion from a single enemy contributed to the EXP-EZ dispenser was capped at the amount of XP it would take for that mon to go to the level one above the cap. This would have taken substantially longer to solve without that side effect. I will not be re-implementing that side-effect in the near future